### PR TITLE
URenderPass: Rename to URenderPassLegacyImpl

### DIFF
--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -67,7 +67,7 @@ import net.minecraft.client.renderer.Tessellator;
 //#if MC>=12106
 //$$ import com.mojang.blaze3d.systems.RenderPass;
 //$$ import com.mojang.blaze3d.textures.GpuTextureView;
-//$$ import gg.essential.universal.render.URenderPass;
+//$$ import gg.essential.universal.render.URenderPassLegacyImpl;
 //$$ import gg.essential.universal.render.URenderPipeline;
 //$$ import gg.essential.universal.vertex.UBuiltBuffer;
 //$$ import net.minecraft.client.font.BakedGlyph;
@@ -722,9 +722,9 @@ public class UGraphics {
                 //#else
                 //$$ GpuTextureView lightTexture = MinecraftClient.getInstance().gameRenderer.getLightmapTextureManager().getGlTextureView();
                 //#endif
-    //$$             try (URenderPass renderPass = new URenderPass()) {
+    //$$             try (URenderPassLegacyImpl renderPass = new URenderPassLegacyImpl()) {
     //$$                 renderPass.draw(UBuiltBuffer.wrap(builtBuffer), URenderPipeline.wrap(pipeline), builder -> {
-    //$$                     RenderPass mcRenderPass = ((URenderPass.DrawCallBuilderImpl) builder).getMc();
+    //$$                     RenderPass mcRenderPass = ((URenderPassLegacyImpl.DrawCallBuilderImpl) builder).getMc();
                         //#if MC>=12111
                         //$$ mcRenderPass.bindTexture("Sampler0", texture, RenderSystem.getSamplerCache().get(FilterMode.NEAREST));
                         //$$ mcRenderPass.bindTexture("Sampler2", lightTexture, RenderSystem.getSamplerCache().get(FilterMode.LINEAR));

--- a/src/main/kotlin/gg/essential/universal/render/URenderPassLegacyImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPassLegacyImpl.kt
@@ -38,12 +38,19 @@ import kotlin.ranges.coerceIn
 //#endif
 //#endif
 
-// Kept internal for now because I'm not yet sure how Mojang will evolve their RenderPass.
-// At the moment we can't keep it open across draw calls because MC prevents uploading any new buffers while the render
-// pass is active. Not sure if that's intentional.
-// For older versions it would definitely be useful to issue multiple draw calls via one URenderPass object because
-// we can cache the global GL state between calls and don't need to re-query and reset everything on every draw.
-internal class URenderPass : AutoCloseable {
+/**
+ * Legacy [DrawCallBuilder]-based render pass implementation.
+ * Compared to proper URenderPass, it has the following shortcomings:
+ * - Always draws to the main MC framebuffer (with RenderSystem override on versions that support it).
+ * - Implicitly uses global scissor state if not explicitly specified.
+ * - Implicitly uses global dynamic uniforms (e.g. model-view matrix, texture matrix, model offset, etc.).
+ * - Implicitly uses global default uniforms (e.g. projection matrix).
+ * - Only supports rendering from [UBuiltBuffer]. No way to render the same buffer multiple times. No way to specify
+ *   custom index buffer.
+ * - Uses a separate underlying MC `RenderPass` for each draw because it may need to write to GpuBuffers before each
+ *   draw and writing to buffers is not supported during a `RenderPass`.
+ */
+internal class URenderPassLegacyImpl : AutoCloseable {
     //#if MC>=12105 && !STANDALONE
     //#else
     private val prevGlState = ManagedGlState.active()

--- a/src/main/kotlin/gg/essential/universal/vertex/UBuiltBuffer.kt
+++ b/src/main/kotlin/gg/essential/universal/vertex/UBuiltBuffer.kt
@@ -1,7 +1,7 @@
 package gg.essential.universal.vertex
 
 import gg.essential.universal.render.DrawCallBuilder
-import gg.essential.universal.render.URenderPass
+import gg.essential.universal.render.URenderPassLegacyImpl
 import gg.essential.universal.render.URenderPipeline
 import org.jetbrains.annotations.ApiStatus.NonExtendable
 
@@ -34,7 +34,7 @@ interface UBuiltBuffer : AutoCloseable {
         use { draw(pipeline, configure) }
 
     fun draw(pipeline: URenderPipeline, configure: DrawCallBuilder.() -> Unit = {}) {
-        URenderPass().use { renderPass ->
+        URenderPassLegacyImpl().use { renderPass ->
             renderPass.draw(this, pipeline, configure)
         }
     }


### PR DESCRIPTION
Renaming because I'll soon introduce a full `URenderPass` API.

The old class has been kept `internal`, so we can just rename it.