### PR TITLE
UGpuDevice: Fix incorrect sampler used on 1.21.5-1.21.10

### DIFF
--- a/src/main/kotlin/gg/essential/universal/render/UGpuSamplerImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuSamplerImpl.kt
@@ -6,6 +6,8 @@ import gg.essential.universal.render.UGpuSampler.FilterMode
 //#if MC >= 1.21.11 && !STANDALONE
 //$$ import com.mojang.blaze3d.systems.RenderSystem
 //$$ import net.minecraft.client.gl.GpuSampler
+//#elseif MC >= 1.21.6 && !STANDALONE
+//$$ import com.mojang.blaze3d.textures.GpuTexture
 //#else
 import gg.essential.universal.UGraphics
 import org.lwjgl.opengl.GL11
@@ -26,6 +28,23 @@ internal data class UGpuSamplerImpl(
     val useMipmaps: Boolean,
 ) : UGpuSampler {
 
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ private val AddressMode.mc: com.mojang.blaze3d.textures.AddressMode
+    //$$     get() = when (this) {
+    //$$         AddressMode.REPEAT -> com.mojang.blaze3d.textures.AddressMode.REPEAT
+    //$$         AddressMode.CLAMP_TO_EDGE -> com.mojang.blaze3d.textures.AddressMode.CLAMP_TO_EDGE
+    //$$     }
+    //$$ private val FilterMode.mc: com.mojang.blaze3d.textures.FilterMode
+    //$$     get() = when (this) {
+    //$$         FilterMode.NEAREST -> com.mojang.blaze3d.textures.FilterMode.NEAREST
+    //$$         FilterMode.LINEAR -> com.mojang.blaze3d.textures.FilterMode.LINEAR
+    //$$     }
+    //$$
+    //$$ fun configureTexture(texture: GpuTexture) {
+    //$$     texture.setAddressMode(addressModeU.mc, addressModeV.mc)
+    //$$     texture.setTextureFilter(minFilter.mc, magFilter.mc, useMipmaps)
+    //$$ }
+    //#else
     private val AddressMode.gl: Int
         get() = when (this) {
             AddressMode.REPEAT -> GL11.GL_REPEAT
@@ -46,5 +65,6 @@ internal data class UGpuSamplerImpl(
             GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MAX_LOD, if (useMipmaps) 1000f else 0f)
         }
     }
+    //#endif
 }
 //#endif

--- a/src/main/kotlin/gg/essential/universal/render/URenderPassLegacyImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPassLegacyImpl.kt
@@ -224,7 +224,7 @@ internal class URenderPassLegacyImpl : AutoCloseable {
             //#if MC >= 1.21.11
             //$$ mc.bindTexture(name, textureView.impl.mc, sampler.impl.mc)
             //#elseif MC >= 1.21.6
-            //$$ sampler.impl.configureTexture((textureView.texture.impl.mc as GlTexture).glId)
+            //$$ sampler.impl.configureTexture(textureView.texture.impl.mc)
             //$$ mc.bindSampler(name, textureView.impl.mc)
             //#else
             //$$ sampler.impl.configureTexture((textureView.texture.impl.mc as GlTexture).glId)


### PR DESCRIPTION
`GlCommandEncoder.setupRenderPass` will (until 1.21.11, when MC introduces the `GpuSampler` type) apply the address/filter mode of the `GlTexture` object if that is marked as dirty, overwriting our `UGpuSampler` on those versions.

This commit fixes that by configuring the `GlTexture` object on those versions, instead of the underlying GL texture directly.