### PR TITLE
New renderer

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1216,19 +1216,21 @@ public abstract interface class gg/essential/universal/render/UGpuTextureView : 
 public final class gg/essential/universal/render/URenderPipeline {
 	public static final field Companion Lgg/essential/universal/render/URenderPipeline$Companion;
 	@1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge
-	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.21.11-neoforge,26.1-fabric,26.1-neoforge,26.2-fabric
-	public synthetic fun <init> (Lnet/minecraft/resources/Identifier;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/shaders/ShaderSource;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/resources/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/shaders/ShaderSource;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.21.11-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/client/gl/ShaderSourceGetter;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/client/gl/ShaderSourceGetter;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
-	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lnet/minecraft/client/render/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lnet/minecraft/client/render/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
-	public synthetic fun <init> (Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/client/renderer/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lnet/minecraft/client/renderer/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCommonVertexFormat ()Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public final fun getDrawMode ()Lgg/essential/universal/UGraphics$DrawMode;
 	public fun toString ()Ljava/lang/String;
 	@1.21.11-fabric,1.21.11-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric,1.21.7-fabric,1.21.7-forge,1.21.7-neoforge,1.21.9-fabric,26.1-fabric,26.1-neoforge,26.2-fabric
 	public static final fun wrap (Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lgg/essential/universal/render/URenderPipeline;

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1191,7 +1191,17 @@ public abstract interface class gg/essential/universal/render/UGpuDevice {
 	public static synthetic fun createTexture$default (Lgg/essential/universal/render/UGpuDevice;Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;IIIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTexture;
 	public abstract fun createTextureView (Lgg/essential/universal/render/UGpuTexture;II)Lgg/essential/universal/render/UGpuTextureView;
 	public static synthetic fun createTextureView$default (Lgg/essential/universal/render/UGpuDevice;Lgg/essential/universal/render/UGpuTexture;IIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTextureView;
+	public abstract fun getInfo ()Lgg/essential/universal/render/UGpuDevice$Info;
 	public abstract fun mapBuffer (Lgg/essential/universal/render/UGpuBufferSlice;ZZ)Lgg/essential/universal/render/UGpuDevice$MappedBuffer;
+}
+
+public abstract interface class gg/essential/universal/render/UGpuDevice$Info {
+	public abstract fun getLimits ()Lgg/essential/universal/render/UGpuDevice$Limits;
+	public abstract fun isZZeroToOne ()Z
+}
+
+public abstract interface class gg/essential/universal/render/UGpuDevice$Limits {
+	public abstract fun maxTextureSize (Lgg/essential/universal/render/UGpuFormat;)I
 }
 
 public abstract interface class gg/essential/universal/render/UGpuDevice$MappedBuffer : java/lang/AutoCloseable {

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1118,10 +1118,15 @@ public abstract interface class gg/essential/universal/render/DrawCallBuilder {
 }
 
 public abstract interface class gg/essential/universal/render/UGpuDevice {
+	public abstract fun createFence ()Lgg/essential/universal/render/UGpuFence;
 	public abstract fun createTexture (Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;III)Lgg/essential/universal/render/UGpuTexture;
 	public static synthetic fun createTexture$default (Lgg/essential/universal/render/UGpuDevice;Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;IIIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTexture;
 	public abstract fun createTextureView (Lgg/essential/universal/render/UGpuTexture;II)Lgg/essential/universal/render/UGpuTextureView;
 	public static synthetic fun createTextureView$default (Lgg/essential/universal/render/UGpuDevice;Lgg/essential/universal/render/UGpuTexture;IIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTextureView;
+}
+
+public abstract interface class gg/essential/universal/render/UGpuFence : java/lang/AutoCloseable {
+	public abstract fun awaitCompletion (J)Z
 }
 
 public abstract interface class gg/essential/universal/render/UGpuFormat {

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1704,6 +1704,7 @@ public abstract interface class gg/essential/universal/vertex/UBuiltBuffer : jav
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.11-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
 	public fun drawAndClose (Lnet/minecraft/client/render/RenderLayer;)V
 	public static synthetic fun drawAndClose$default (Lgg/essential/universal/vertex/UBuiltBuffer;Lgg/essential/universal/render/URenderPipeline;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun toByteBuffer ()Ljava/nio/ByteBuffer;
 	@1.8.9-forge
 	public static fun wrap (Lnet/minecraft/client/renderer/WorldRenderer;)Lgg/essential/universal/vertex/UBuiltBuffer;
 	@1.21-forge,1.21-neoforge,1.21.11-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge,26.1-fabric,26.1-neoforge,26.2-fabric

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1176,6 +1176,11 @@ public abstract interface class gg/essential/universal/render/UGpuDevice {
 	public static synthetic fun createTexture$default (Lgg/essential/universal/render/UGpuDevice;Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;IIIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTexture;
 	public abstract fun createTextureView (Lgg/essential/universal/render/UGpuTexture;II)Lgg/essential/universal/render/UGpuTextureView;
 	public static synthetic fun createTextureView$default (Lgg/essential/universal/render/UGpuDevice;Lgg/essential/universal/render/UGpuTexture;IIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTextureView;
+	public abstract fun mapBuffer (Lgg/essential/universal/render/UGpuBufferSlice;ZZ)Lgg/essential/universal/render/UGpuDevice$MappedBuffer;
+}
+
+public abstract interface class gg/essential/universal/render/UGpuDevice$MappedBuffer : java/lang/AutoCloseable {
+	public abstract fun getData ()Ljava/nio/ByteBuffer;
 }
 
 public abstract interface class gg/essential/universal/render/UGpuFence : java/lang/AutoCloseable {

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1173,6 +1173,7 @@ public abstract interface class gg/essential/universal/render/UGpuDevice {
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;J)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;Ljava/nio/ByteBuffer;)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createFence ()Lgg/essential/universal/render/UGpuFence;
+	public abstract fun createRenderPass (Lgg/essential/universal/render/URenderPassDescriptor;)Lgg/essential/universal/render/URenderPass;
 	public abstract fun createTexture (Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;III)Lgg/essential/universal/render/UGpuTexture;
 	public static synthetic fun createTexture$default (Lgg/essential/universal/render/UGpuDevice;Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;IIIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTexture;
 	public abstract fun createTextureView (Lgg/essential/universal/render/UGpuTexture;II)Lgg/essential/universal/render/UGpuTextureView;
@@ -1289,16 +1290,86 @@ public abstract interface class gg/essential/universal/render/UGpuTextureView : 
 	public abstract fun isClosed ()Z
 }
 
+public abstract interface class gg/essential/universal/render/URenderPass : java/lang/AutoCloseable {
+	public abstract fun draw (IIII)V
+	public static synthetic fun draw$default (Lgg/essential/universal/render/URenderPass;IIIIILjava/lang/Object;)V
+	public abstract fun drawIndexed (IIIII)V
+	public static synthetic fun drawIndexed$default (Lgg/essential/universal/render/URenderPass;IIIIIILjava/lang/Object;)V
+	public abstract fun indexBuffer (Lgg/essential/universal/render/UGpuBuffer;Lgg/essential/universal/render/URenderPass$IndexType;)V
+	public abstract fun modelViewMatrix ([F)V
+	public abstract fun pipeline (Lgg/essential/universal/render/URenderPipeline;)V
+	public abstract fun projectionMatrix ([F)V
+	public abstract fun scissor (IIII)V
+	public abstract fun texture (Ljava/lang/String;Lgg/essential/universal/render/UGpuTextureView;Lgg/essential/universal/render/UGpuSampler;)V
+	public abstract fun uniform (Ljava/lang/String;Lgg/essential/universal/render/UGpuBufferSlice;)V
+	public abstract fun uniform (Ljava/lang/String;[F)V
+	public abstract fun uniform (Ljava/lang/String;[I)V
+	public abstract fun vertexBuffer (ILgg/essential/universal/render/UGpuBufferSlice;)V
+}
+
+public final class gg/essential/universal/render/URenderPass$IndexType : java/lang/Enum {
+	public static final field INT Lgg/essential/universal/render/URenderPass$IndexType;
+	public static final field SHORT Lgg/essential/universal/render/URenderPass$IndexType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lgg/essential/universal/render/URenderPass$IndexType;
+	public static fun values ()[Lgg/essential/universal/render/URenderPass$IndexType;
+}
+
+public final class gg/essential/universal/render/URenderPassDescriptor {
+	public fun <init> (Ljava/util/function/Supplier;)V
+	public final fun withColorAttachment (Lgg/essential/universal/render/UGpuTextureView;Lgg/essential/universal/render/URenderPassDescriptor$ClearColor;)Lgg/essential/universal/render/URenderPassDescriptor;
+	public static synthetic fun withColorAttachment$default (Lgg/essential/universal/render/URenderPassDescriptor;Lgg/essential/universal/render/UGpuTextureView;Lgg/essential/universal/render/URenderPassDescriptor$ClearColor;ILjava/lang/Object;)Lgg/essential/universal/render/URenderPassDescriptor;
+	public final fun withDepthAttachment (Lgg/essential/universal/render/UGpuTextureView;Ljava/lang/Double;)Lgg/essential/universal/render/URenderPassDescriptor;
+	public static synthetic fun withDepthAttachment$default (Lgg/essential/universal/render/URenderPassDescriptor;Lgg/essential/universal/render/UGpuTextureView;Ljava/lang/Double;ILjava/lang/Object;)Lgg/essential/universal/render/URenderPassDescriptor;
+	public final fun withRenderArea (Lgg/essential/universal/render/URenderPassDescriptor$RenderArea;)Lgg/essential/universal/render/URenderPassDescriptor;
+}
+
+public final class gg/essential/universal/render/URenderPassDescriptor$ClearColor {
+	public fun <init> (FFFF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun component4 ()F
+	public final fun copy (FFFF)Lgg/essential/universal/render/URenderPassDescriptor$ClearColor;
+	public static synthetic fun copy$default (Lgg/essential/universal/render/URenderPassDescriptor$ClearColor;FFFFILjava/lang/Object;)Lgg/essential/universal/render/URenderPassDescriptor$ClearColor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlpha ()F
+	public final fun getBlue ()F
+	public final fun getGreen ()F
+	public final fun getRed ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class gg/essential/universal/render/URenderPassDescriptor$RenderArea {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lgg/essential/universal/render/URenderPassDescriptor$RenderArea;
+	public static synthetic fun copy$default (Lgg/essential/universal/render/URenderPassDescriptor$RenderArea;IIIIILjava/lang/Object;)Lgg/essential/universal/render/URenderPassDescriptor$RenderArea;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class gg/essential/universal/render/URenderPipeline {
 	public static final field Companion Lgg/essential/universal/render/URenderPipeline$Companion;
-	@1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge
-	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	@1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	@1.21.11-neoforge,26.1-fabric,26.1-neoforge,26.2-fabric
+	@26.1-fabric,26.1-neoforge,26.2-fabric
 	public synthetic fun <init> (Lnet/minecraft/resources/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/shaders/ShaderSource;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	@1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge
+	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lgg/essential/universal/render/URenderPipeline$DepthTest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	@1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lgg/essential/universal/render/URenderPipeline$DepthTest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	@1.21.11-neoforge
+	public synthetic fun <init> (Lnet/minecraft/resources/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/shaders/ShaderSource;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lgg/essential/universal/render/URenderPipeline$DepthTest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.21.11-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/client/gl/ShaderSourceGetter;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/client/gl/ShaderSourceGetter;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lgg/essential/universal/render/URenderPipeline$DepthTest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
 	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1169,6 +1169,7 @@ public final class gg/essential/universal/render/UGpuBufferSlice {
 }
 
 public abstract interface class gg/essential/universal/render/UGpuDevice {
+	public abstract fun copyBufferToTexture (Lgg/essential/universal/render/UGpuBufferSlice;IIIILgg/essential/universal/render/UGpuTexture;IIIIII)V
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;J)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;Ljava/nio/ByteBuffer;)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createFence ()Lgg/essential/universal/render/UGpuFence;

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1117,6 +1117,17 @@ public abstract interface class gg/essential/universal/render/DrawCallBuilder {
 	public abstract fun uniform (Ljava/lang/String;[I)Lgg/essential/universal/render/DrawCallBuilder;
 }
 
+public abstract interface class gg/essential/universal/render/SharedIndexBuffer {
+	public abstract fun invoke (I)Lkotlin/Pair;
+}
+
+public final class gg/essential/universal/render/SharedIndexBuffers {
+	public static final field INSTANCE Lgg/essential/universal/render/SharedIndexBuffers;
+	public final fun getQuads ()Lgg/essential/universal/render/SharedIndexBuffer;
+	public final fun getSequential ()Lgg/essential/universal/render/SharedIndexBuffer;
+	public final fun getTriangleFan ()Lgg/essential/universal/render/SharedIndexBuffer;
+}
+
 public abstract interface class gg/essential/universal/render/UGpuBuffer : java/io/Closeable {
 	public abstract fun getSize ()J
 	public abstract fun isClosed ()Z

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1459,6 +1459,35 @@ public final class gg/essential/universal/render/URenderPipeline$DepthTest : jav
 	public static fun values ()[Lgg/essential/universal/render/URenderPipeline$DepthTest;
 }
 
+public final class gg/essential/universal/render/font/UFontRenderer : java/lang/AutoCloseable {
+	public fun <init> ()V
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.11-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge,26.1-fabric,26.1-neoforge,26.2-fabric
+	public fun <init> (Lnet/minecraft/client/gui/Font;)V
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.11-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
+	public fun <init> (Lnet/minecraft/client/font/TextRenderer;)V
+	@1.12.2-forge,1.16.2-forge,1.8.9-forge
+	public fun <init> (Lnet/minecraft/client/gui/FontRenderer;)V
+	public fun close ()V
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.11-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge,1.21.7-forge,1.21.7-neoforge,26.1-fabric,26.1-neoforge,26.2-fabric
+	public final fun getMc ()Lnet/minecraft/client/gui/Font;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.11-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric,1.21.7-fabric,1.21.9-fabric
+	public final fun getMc ()Lnet/minecraft/client/font/TextRenderer;
+	@1.12.2-forge,1.16.2-forge,1.8.9-forge
+	public final fun getMc ()Lnet/minecraft/client/gui/FontRenderer;
+	public final fun render (Lgg/essential/universal/render/UGpuTextureView;Ljava/util/List;)V
+}
+
+public final class gg/essential/universal/render/font/UFontRenderer$Text {
+	public fun <init> (IIFLjava/lang/String;IZLjava/lang/Integer;)V
+	public final fun getColor ()I
+	public final fun getScale ()F
+	public final fun getShadow ()Z
+	public final fun getShadowColor ()Ljava/lang/Integer;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getX ()I
+	public final fun getY ()I
+}
+
 public final class gg/essential/universal/shader/BlendState {
 	public static final field ALPHA Lgg/essential/universal/shader/BlendState;
 	public static final field Companion Lgg/essential/universal/shader/BlendState$Companion;

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -930,6 +930,8 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public fun setNewGuiScale (I)V
 	public fun setUnlocalizedName (Ljava/lang/String;)V
 	public final fun tick ()V
+	public fun uCreateRenderer ()Lgg/essential/universal/UScreen$Renderer;
+	public fun uExtractRenderState (IIF)Lgg/essential/universal/UScreen$RenderState;
 	public fun updateGuiScale ()V
 }
 
@@ -1020,6 +1022,8 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public fun setNewGuiScale (I)V
 	public fun setUnlocalizedName (Ljava/lang/String;)V
 	public final fun tick ()V
+	public fun uCreateRenderer ()Lgg/essential/universal/UScreen$Renderer;
+	public fun uExtractRenderState (IIF)Lgg/essential/universal/UScreen$RenderState;
 	public fun updateGuiScale ()V
 }
 
@@ -1065,6 +1069,8 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public final fun restorePreviousScreen ()V
 	public fun setNewGuiScale (I)V
 	public fun setUnlocalizedName (Ljava/lang/String;)V
+	public fun uCreateRenderer ()Lgg/essential/universal/UScreen$Renderer;
+	public fun uExtractRenderState (IIF)Lgg/essential/universal/UScreen$RenderState;
 	public fun updateGuiScale ()V
 	public final fun updateScreen ()V
 }
@@ -1082,6 +1088,15 @@ public final class gg/essential/universal/UScreen$Companion {
 	public final fun displayScreen (Lnet/minecraft/client/gui/GuiScreen;)V
 	@1.12.2-forge,1.8.9-forge
 	public final fun getCurrentScreen ()Lnet/minecraft/client/gui/GuiScreen;
+	public final fun isRendererRequired ()Z
+}
+
+public abstract interface class gg/essential/universal/UScreen$RenderState {
+	public abstract fun getBackground ()Z
+}
+
+public abstract interface class gg/essential/universal/UScreen$Renderer : java/lang/AutoCloseable {
+	public abstract fun render (Lgg/essential/universal/UScreen$RenderState;)Lgg/essential/universal/render/UGpuTextureView;
 }
 
 public final class gg/essential/universal/USound {

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1169,6 +1169,8 @@ public final class gg/essential/universal/render/UGpuBufferSlice {
 }
 
 public abstract interface class gg/essential/universal/render/UGpuDevice {
+	public abstract fun clearColor (Lgg/essential/universal/render/UGpuTexture;FFFF)V
+	public abstract fun clearDepth (Lgg/essential/universal/render/UGpuTexture;D)V
 	public abstract fun copyBufferToTexture (Lgg/essential/universal/render/UGpuBufferSlice;IIIILgg/essential/universal/render/UGpuTexture;IIIIII)V
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;J)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;Ljava/nio/ByteBuffer;)Lgg/essential/universal/render/UGpuBuffer;

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1117,7 +1117,60 @@ public abstract interface class gg/essential/universal/render/DrawCallBuilder {
 	public abstract fun uniform (Ljava/lang/String;[I)Lgg/essential/universal/render/DrawCallBuilder;
 }
 
+public abstract interface class gg/essential/universal/render/UGpuBuffer : java/io/Closeable {
+	public abstract fun getSize ()J
+	public abstract fun isClosed ()Z
+	public fun slice (JJ)Lgg/essential/universal/render/UGpuBufferSlice;
+	public static synthetic fun slice$default (Lgg/essential/universal/render/UGpuBuffer;JJILjava/lang/Object;)Lgg/essential/universal/render/UGpuBufferSlice;
+}
+
+public final class gg/essential/universal/render/UGpuBuffer$Usage {
+	public static final field Companion Lgg/essential/universal/render/UGpuBuffer$Usage$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun contains (Lgg/essential/universal/render/UGpuBuffer$Usage;)Z
+	public final fun copy (I)Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public static synthetic fun copy$default (Lgg/essential/universal/render/UGpuBuffer$Usage;IILjava/lang/Object;)Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBits ()I
+	public fun hashCode ()I
+	public final fun plus (Lgg/essential/universal/render/UGpuBuffer$Usage;)Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class gg/essential/universal/render/UGpuBuffer$Usage$Companion {
+	public final fun getCOPY_DST ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getCOPY_SRC ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getHINT_CLIENT_STORAGE ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getINDEX ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getINDIRECT_PARAMETERS ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getMAP_READ ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getMAP_WRITE ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getUNIFORM ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getUNIFORM_TEXEL_BUFFER ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+	public final fun getVERTEX ()Lgg/essential/universal/render/UGpuBuffer$Usage;
+}
+
+public final class gg/essential/universal/render/UGpuBufferSlice {
+	public fun <init> (Lgg/essential/universal/render/UGpuBuffer;JJ)V
+	public final fun component1 ()Lgg/essential/universal/render/UGpuBuffer;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun copy (Lgg/essential/universal/render/UGpuBuffer;JJ)Lgg/essential/universal/render/UGpuBufferSlice;
+	public static synthetic fun copy$default (Lgg/essential/universal/render/UGpuBufferSlice;Lgg/essential/universal/render/UGpuBuffer;JJILjava/lang/Object;)Lgg/essential/universal/render/UGpuBufferSlice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuffer ()Lgg/essential/universal/render/UGpuBuffer;
+	public final fun getOffset ()J
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public final fun slice (JJ)Lgg/essential/universal/render/UGpuBufferSlice;
+	public static synthetic fun slice$default (Lgg/essential/universal/render/UGpuBufferSlice;JJILjava/lang/Object;)Lgg/essential/universal/render/UGpuBufferSlice;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class gg/essential/universal/render/UGpuDevice {
+	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;J)Lgg/essential/universal/render/UGpuBuffer;
+	public abstract fun createBuffer (Lgg/essential/universal/render/UGpuBuffer$Usage;Ljava/nio/ByteBuffer;)Lgg/essential/universal/render/UGpuBuffer;
 	public abstract fun createFence ()Lgg/essential/universal/render/UGpuFence;
 	public abstract fun createTexture (Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;III)Lgg/essential/universal/render/UGpuTexture;
 	public static synthetic fun createTexture$default (Lgg/essential/universal/render/UGpuDevice;Ljava/lang/String;Lgg/essential/universal/render/UGpuTexture$Usage;Lgg/essential/universal/render/UGpuFormat;IIIILjava/lang/Object;)Lgg/essential/universal/render/UGpuTexture;
@@ -1139,6 +1192,18 @@ public final class gg/essential/universal/render/UGpuFormat$Companion {
 }
 
 public abstract interface class gg/essential/universal/render/UGpuPlatformAdapter {
+	@1.21.11-fabric,1.21.11-neoforge,1.21.6-fabric,1.21.7-fabric,1.21.7-forge,1.21.7-neoforge,1.21.9-fabric,26.1-fabric,26.1-neoforge,26.2-fabric
+	public abstract fun buffer (Lcom/mojang/blaze3d/buffers/GpuBuffer;)Lgg/essential/universal/render/UGpuBuffer;
+	@1.21.11-fabric,1.21.11-neoforge,1.21.6-fabric,1.21.7-fabric,1.21.7-forge,1.21.7-neoforge,1.21.9-fabric,26.1-fabric,26.1-neoforge,26.2-fabric
+	public abstract fun buffer (Lgg/essential/universal/render/UGpuBuffer;)Lcom/mojang/blaze3d/buffers/GpuBuffer;
+	@1.21.11-fabric,1.21.11-neoforge,1.21.6-fabric,1.21.7-fabric,1.21.7-forge,1.21.7-neoforge,1.21.9-fabric,26.1-fabric,26.1-neoforge,26.2-fabric
+	public abstract fun bufferSlice (Lcom/mojang/blaze3d/buffers/GpuBufferSlice;)Lgg/essential/universal/render/UGpuBufferSlice;
+	@1.21.11-fabric,1.21.11-neoforge,1.21.6-fabric,1.21.7-fabric,1.21.7-forge,1.21.7-neoforge,1.21.9-fabric,26.1-fabric,26.1-neoforge,26.2-fabric
+	public abstract fun bufferSlice (Lgg/essential/universal/render/UGpuBufferSlice;)Lcom/mojang/blaze3d/buffers/GpuBufferSlice;
+	@1.12.2-forge,1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.17.1-forge,1.18.1-fabric,1.18.1-forge,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.2-forge,1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.8.9-forge
+	public abstract fun buffer (ILgg/essential/universal/render/UGpuBuffer$Usage;J)Lgg/essential/universal/render/UGpuBuffer;
+	@1.12.2-forge,1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.17.1-forge,1.18.1-fabric,1.18.1-forge,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.2-forge,1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.8.9-forge
+	public abstract fun buffer (Lgg/essential/universal/render/UGpuBuffer;)I
 	public abstract fun getDefaultGpuFormatDepth ()Lgg/essential/universal/render/UGpuFormat;
 	public abstract fun getDefaultGpuFormatRgba ()Lgg/essential/universal/render/UGpuFormat;
 	@26.2-fabric

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -80,7 +80,7 @@ preprocess {
     fabric12104.link(fabric12103)
     neoForge12103.link(fabric12103)
     forge12103.link(fabric12103)
-    fabric12103.link(fabric12100)
+    fabric12103.link(fabric12100, file("versions/1.21.3-1.21.txt"))
     neoForge12100.link(fabric12100)
     forge12100.link(fabric12100)
     fabric12100.link(fabric12006, file("versions/1.21-1.20.6.txt"))

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -1143,8 +1143,13 @@ public class UGraphics {
         //$$ }
         //#endif
 
-        //#if MC >= 1.17 && MC < 26.2
-        //$$ private static DrawMode fromMc(VertexFormat.DrawMode mcMode) {
+        //#if MC >= 1.17 && !STANDALONE
+        //$$ @ApiStatus.Internal
+        //#if MC >= 26.2
+        //$$ public static DrawMode fromMc(PrimitiveTopology mcMode) {
+        //#else
+        //$$ public static DrawMode fromMc(VertexFormat.DrawMode mcMode) {
+        //#endif
         //$$     switch (mcMode) {
         //$$         case LINES: return DrawMode.LINES;
                 //#if MC>=12111

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -163,7 +163,8 @@ public class UGraphics {
     //$$ public static void init() { /* triggers static initializer */ }
     //$$ @ApiStatus.Internal
     //$$ public static final Gl2Renderer RENDERER = new Gl2Renderer();
-    //$$ private static final NvgFont MC_FONT;
+    //$$ @ApiStatus.Internal
+    //$$ public static final NvgFont MC_FONT;
     //$$ static {
     //$$     URL fontUrl = UGraphics.class.getResource("/fonts/Minecraft-Regular.otf");
     //$$     assert fontUrl != null;

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -1452,7 +1452,16 @@ public class UGraphics {
     //$$     if (vertexFormat == null) {
     //$$         throw new IllegalStateException("Must call `begin` before `draw`.");
     //$$     }
-    //$$     RENDERER.draw(instance, drawMode, shader);
+    //$$     if (shader != null) {
+    //$$         if (shader.getUSampler() != null) {
+    //$$             shader.getUSampler().setValue(GL20.glGetInteger(GL20.GL_TEXTURE_BINDING_2D));
+    //$$         }
+    //$$         shader.getShader().bind();
+    //$$     }
+    //$$     RENDERER.draw(instance, drawMode);
+    //$$     if (shader != null) {
+    //$$         shader.getShader().unbind();
+    //$$     }
     //$$ }
     //#else
     private void doDraw(

--- a/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
+++ b/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
@@ -236,11 +236,7 @@ class UMatrixStack private constructor(
         stack.last.model.store(MATRIX_BUFFER)
         // Explicit cast to Buffer required so we do not use the JDK9+ override in FloatBuffer
         (MATRIX_BUFFER as Buffer).rewind()
-        //#if MC>=11500
-        //$$ GL11.glMultMatrixf(MATRIX_BUFFER)
-        //#else
         GL11.glMultMatrix(MATRIX_BUFFER)
-        //#endif
         //#endif
     }
 

--- a/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -16,6 +16,7 @@ import java.awt.Color
 //#endif
 
 //#if MC>=12106
+//$$ import gg.essential.universal.utils.drawTexture
 //$$ import com.mojang.blaze3d.systems.RenderSystem
 //#endif
 
@@ -132,7 +133,7 @@ abstract class UScreen(
     //$$
     //$$         val textureView = renderer.render(renderState)
             //#if MC >= 1.21.6
-            //$$ advancedDrawContext.draw(context, textureView)
+            //$$ context.drawTexture(textureView)
             //#else
             //$$ drawImmediate(UMatrixStack(context.matrices), textureView)
             //#endif

--- a/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -1,6 +1,12 @@
 package gg.essential.universal
 
+import gg.essential.universal.render.UGpuSampler
+import gg.essential.universal.render.UGpuTextureView
+import gg.essential.universal.render.URenderPipeline
+import gg.essential.universal.shader.BlendState
+import gg.essential.universal.vertex.UBufferBuilder
 import net.minecraft.client.gui.GuiScreen
+import java.awt.Color
 
 //#if MC>=12109
 //$$ import net.minecraft.client.gui.Click
@@ -113,6 +119,28 @@ abstract class UScreen(
     //$$
     //#if MC>=12000
     //$$ final override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
+    //$$     val renderer = renderer ?: uCreateRenderer().also { renderer = it }
+    //$$     if (renderer != null) {
+    //$$         val renderState = uExtractRenderState(mouseX, mouseY, delta)
+    //$$
+    //$$         drawContexts.add(context)
+    //$$         superDrawScreen(UMatrixStack(context.matrices), mouseX, mouseY, delta)
+    //$$         if (renderState.background) {
+    //$$             onDrawBackground(UMatrixStack(context.matrices), 0)
+    //$$         }
+    //$$         drawContexts.removeLast()
+    //$$
+    //$$         val textureView = renderer.render(renderState)
+            //#if MC >= 1.21.6
+            //$$ advancedDrawContext.draw(context, textureView)
+            //#else
+            //$$ drawImmediate(UMatrixStack(context.matrices), textureView)
+            //#endif
+    //$$         return
+    //$$     }
+    //#if MC >= 26.3
+    //$$     throw NullPointerException("uCreateRenderer returned `null` but `onDrawScreen` is not supported on this version")
+    //#else
     //$$     drawContexts.add(context)
         //#if MC>=12106
         //$$ advancedDrawContext.nextFrame()
@@ -125,6 +153,7 @@ abstract class UScreen(
         //$$ onDrawScreenCompat(UMatrixStack(context.matrices), mouseX, mouseY, delta)
         //#endif
     //$$     drawContexts.removeLast()
+    //#endif
     //#elseif MC>=11602
     //$$ final override fun render(matrixStack: MatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
     //$$     onDrawScreenCompat(UMatrixStack(matrixStack), mouseX, mouseY, partialTicks)
@@ -241,6 +270,8 @@ abstract class UScreen(
     //$$ final override fun tick(): Unit = onTick()
     //$$
     //$$ final override fun onClose() {
+    //$$     renderer?.close()
+    //$$     renderer = null
         //#if MC>=12106
         //$$ advancedDrawContext.close()
         //#endif
@@ -317,6 +348,8 @@ abstract class UScreen(
     }
 
     final override fun onGuiClosed() {
+        renderer?.close()
+        renderer = null
         onScreenClose()
         restoreGuiScale()
     }
@@ -366,7 +399,58 @@ abstract class UScreen(
         //#endif
     }
 
+    interface Renderer : AutoCloseable {
+        /**
+         * Renders the given screen state, returns a texture containing the result.
+         *
+         * The given [state] is one returned from [UScreen.uExtractRenderState] of the same screen.
+         * The implementation is free to cast it accordingly.
+         *
+         * The renderer retains ownership over the returned texture, it will not be closed by the caller.
+         * It must remain valid until at least the next [render] call, or [close], whichever happens first.
+         *
+         * Beware that (in a future Minecraft version), this method may be called from a dedicated render thread, and
+         * as such must not access any client state that is not safe to access from multiple threads.
+         * In particular it should use the given [RenderState], that was created on the client thread, rather than
+         * the screen directly.
+         */
+        fun render(state: RenderState): UGpuTextureView
+    }
+
+    /**
+     * A snapshot of all state of this screen which is needed to render it.
+     */
+    interface RenderState {
+        /** Whether the default background should be draw behind this screen. */
+        val background: Boolean
+    }
+
+    /**
+     * Creates a [Renderer] capable of rendering this screen to a texture.
+     * When this method returns non-null, the legacy [onDrawScreen] method will not be used for this screen. Instead
+     * [uExtractRenderState] will be called (and must as such be implemented).
+     *
+     * The [Renderer] returned by this method must be compatible with the [RenderState] type returned by the
+     * [uExtractRenderState] of this screen.
+     */
+    open fun uCreateRenderer(): Renderer? = null
+
+    /**
+     * Takes a snapshot of the current state, as required for rendering it, of this screen.
+     *
+     * Beware that (in a future Minecraft version), the rendering may happen on a dedicated render thread. As such
+     * the returned [RenderState] should be safe to be transferred and used by that thread.
+     *
+     * @see uCreateRenderer
+     * @see RenderState
+     */
+    open fun uExtractRenderState(mouseX: Int, mouseY: Int, partialTicks: Float): RenderState = throw NotImplementedError()
+
     open fun onDrawScreen(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
+        superDrawScreen(matrixStack, mouseX, mouseY, partialTicks)
+    }
+
+    private fun superDrawScreen(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
         //#if MC<12106
         suppressBackground = true
         //#endif
@@ -398,10 +482,43 @@ abstract class UScreen(
         onDrawScreen(UMatrixStack.Compat.get(), mouseX, mouseY, partialTicks)
     }
 
+    private var renderer: Renderer? = null
+
     // Calls the deprecated method (for backwards compat) which then calls the new method (read the deprecation message)
-    private fun onDrawScreenCompat(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) = UMatrixStack.Compat.runLegacyMethod(matrixStack) {
-        @Suppress("DEPRECATION")
-        onDrawScreen(mouseX, mouseY, partialTicks)
+    private fun onDrawScreenCompat(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
+        val renderer = renderer ?: uCreateRenderer()?.also { renderer = it }
+        if (renderer == null) {
+            UMatrixStack.Compat.runLegacyMethod(matrixStack) {
+                @Suppress("DEPRECATION")
+                onDrawScreen(mouseX, mouseY, partialTicks)
+            }
+            return
+        }
+
+        val state = uExtractRenderState(mouseX, mouseY, partialTicks)
+
+        superDrawScreen(matrixStack, mouseX, mouseY, partialTicks)
+        if (state.background) {
+            onDrawBackground(matrixStack, 0)
+        }
+
+        val textureView = renderer.render(state)
+        drawImmediate(matrixStack, textureView)
+    }
+
+    private fun drawImmediate(matrixStack: UMatrixStack, textureView: UGpuTextureView) {
+        val x1 = 0.0
+        val x2 = UResolution.scaledWidth.toDouble()
+        val y1 = 0.0
+        val y2 = UResolution.scaledHeight.toDouble()
+        val buffer = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE)
+        buffer.pos(matrixStack, x1, y2, 0.0).tex(0.0, 0.0).endVertex()
+        buffer.pos(matrixStack, x2, y2, 0.0).tex(1.0, 0.0).endVertex()
+        buffer.pos(matrixStack, x2, y1, 0.0).tex(1.0, 1.0).endVertex()
+        buffer.pos(matrixStack, x1, y1, 0.0).tex(0.0, 1.0).endVertex()
+        buffer.build()?.drawAndClose(PIPELINE_BLIT) {
+            texture(0, textureView, SAMPLER_NEAREST)
+        }
     }
 
     open fun onKeyPressed(keyCode: Int, typedChar: Char, modifiers: UKeyboard.Modifiers?) {
@@ -580,5 +697,29 @@ abstract class UScreen(
         fun displayScreen(screen: GuiScreen?) {
             UMinecraft.currentScreenObj = screen
         }
+
+        /** Whether the [uCreateRenderer] API must be used because the old [onDrawScreen] is no longer supported. */
+        val isRendererRequired: Boolean
+            //#if MC >= 26.3
+            //$$ get() = true
+            //#else
+            get() = false
+            //#endif
+
+        private val PIPELINE_BLIT = URenderPipeline.builderWithDefaultShader(
+            "universalcraft:blit",
+            UGraphics.DrawMode.QUADS,
+            UGraphics.CommonVertexFormats.POSITION_TEXTURE,
+        ).apply {
+            blendState = BlendState.PREMULTIPLIED_ALPHA
+        }.build()
+
+        private val SAMPLER_NEAREST = UGpuSampler(
+            UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+            UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+            UGpuSampler.FilterMode.NEAREST,
+            UGpuSampler.FilterMode.NEAREST,
+            false,
+        )
     }
 }

--- a/src/main/kotlin/gg/essential/universal/render/ScissorState.kt
+++ b/src/main/kotlin/gg/essential/universal/render/ScissorState.kt
@@ -19,13 +19,17 @@ internal data class ScissorState(val enabled: Boolean, val x: Int, val y: Int, v
         //$$     RenderSystem.SCISSOR_STATE.disable()
         //$$ }
         //#else
+        glActivate()
+        //#endif
+    }
+
+    fun glActivate() {
         if (enabled) {
             GL11.glEnable(GL11.GL_SCISSOR_TEST)
         } else {
             GL11.glDisable(GL11.GL_SCISSOR_TEST)
         }
         GL11.glScissor(x, y, width, height)
-        //#endif
     }
 
     fun coerceIn(x: Int, y: Int, width: Int, height: Int): ScissorState {
@@ -63,6 +67,11 @@ internal data class ScissorState(val enabled: Boolean, val x: Int, val y: Int, v
             //#elseif MC==12105
             //$$ return with(RenderSystem.SCISSOR_STATE) { ScissorState(isEnabled, x, y, width, height) }
             //#else
+            return glActive()
+            //#endif
+        }
+
+        fun glActive(): ScissorState {
             val bounds = tmpIntBuffer
                 //#if MC>=11600
                 //$$ .also { GL11.glGetIntegerv(GL11.GL_SCISSOR_BOX, it) }
@@ -76,7 +85,6 @@ internal data class ScissorState(val enabled: Boolean, val x: Int, val y: Int, v
                 width = bounds[2],
                 height = bounds[3],
             )
-            //#endif
         }
     }
 }

--- a/src/main/kotlin/gg/essential/universal/render/SharedIndexBuffers.kt
+++ b/src/main/kotlin/gg/essential/universal/render/SharedIndexBuffers.kt
@@ -1,0 +1,139 @@
+package gg.essential.universal.render
+
+import gg.essential.universal.UGraphics
+import org.jetbrains.annotations.ApiStatus
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.IntBuffer
+
+/**
+ * Provides common shared index buffers for drawing with [URenderPass.drawIndexed].
+ * @see SharedIndexBuffer.invoke
+ */
+object SharedIndexBuffers {
+    /** Identity mapping. Consider using [URenderPass.draw] instead. */
+    val sequential: SharedIndexBuffer =
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ SharedIndexBufferFromMc(UGraphics.DrawMode.TRIANGLES, 1, 1)
+        //#else
+        object : IndexBufferBuilder() {
+            override fun vertCountToIndexCount(vertices: Int): Int = vertices
+
+            override fun fill(buf: IntBuffer) {
+                for (i in 0 until buf.remaining()) {
+                    buf.put(i, i)
+                }
+            }
+        }
+        //#endif
+
+    /** Maps a sequence of four vertices into two triangles to form a quad each: 0 1 2 0 2 3 */
+    val quads: SharedIndexBuffer =
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ SharedIndexBufferFromMc(UGraphics.DrawMode.QUADS, 4, 6)
+        //#else
+        object : IndexBufferBuilder() {
+            override fun vertCountToIndexCount(vertices: Int): Int {
+                require(vertices % 4 == 0)
+                return vertices / 4 * 6
+            }
+
+            override fun fill(buf: IntBuffer) {
+                var vert = 0
+                for (i in 0 until buf.remaining() step 6) {
+                    //  First triangle
+                    buf.put(i + 0, vert + 0)
+                    buf.put(i + 1, vert + 1)
+                    buf.put(i + 2, vert + 2)
+                    // Second triangle
+                    buf.put(i + 3, vert + 0)
+                    buf.put(i + 4, vert + 2)
+                    buf.put(i + 5, vert + 3)
+                    // Advance to next primitive (4 vertices per quad)
+                    vert += 4
+                }
+            }
+        }
+        //#endif
+
+    /** Forms a triangle for each vertex using the previous vertex and the 0th vertex: 0 1 2 0 2 3 0 3 4 0 4 5 */
+    val triangleFan: SharedIndexBuffer =
+        object : IndexBufferBuilder() {
+            override fun vertCountToIndexCount(vertices: Int): Int {
+                require(vertices >= 3)
+                return (vertices - 2) * 3
+            }
+
+            override fun fill(buf: IntBuffer) {
+                var vert = 0
+                for (i in 0 until buf.remaining() step 3) {
+                    buf.put(i + 0, 0)
+                    buf.put(i + 1, vert + 1)
+                    buf.put(i + 2, vert + 2)
+                    vert++
+                }
+            }
+        }
+}
+
+@ApiStatus.NonExtendable
+interface SharedIndexBuffer {
+    /**
+     * Returns an index buffer for drawing [vertices] vertices with [URenderPass.drawIndexed].
+     *
+     * The returned buffer is shared between multiple calls and must not be closed by the caller.
+     * Note: A previously returned buffer may however be invalidated when a larger buffer is requested.
+     *       So only the most recently returned buffer may be assumed valid.
+     */
+    operator fun invoke(vertices: Int): Pair<UGpuBuffer, URenderPass.IndexType>
+}
+
+
+private abstract class IndexBufferBuilder : SharedIndexBuffer {
+    private var gpuBuffer: UGpuBuffer? = null
+
+    override operator fun invoke(vertices: Int): Pair<UGpuBuffer, URenderPass.IndexType> {
+        val indices = vertCountToIndexCount(vertices)
+        val bytesSize = indices * Int.SIZE_BYTES
+
+        val existing = gpuBuffer
+        if (existing != null && existing.size >= bytesSize) return Pair(existing, URenderPass.IndexType.INT)
+
+        val byteBuf = ByteBuffer.allocateDirect(bytesSize).order(ByteOrder.nativeOrder())
+        fill(byteBuf.asIntBuffer())
+
+        val newGpuBuffer = UGraphics.getDevice().createBuffer(UGpuBuffer.Usage.INDEX, byteBuf)
+        gpuBuffer?.close()
+        gpuBuffer = newGpuBuffer
+        return Pair(newGpuBuffer, URenderPass.IndexType.INT)
+    }
+
+    abstract fun vertCountToIndexCount(vertices: Int): Int
+    abstract fun fill(buf: IntBuffer)
+}
+
+//#if MC >= 1.21.6 && !STANDALONE
+//$$ private class SharedIndexBufferFromMc(
+//$$     val drawMode: UGraphics.DrawMode,
+//$$     val verticesPerPrimitive: Int,
+//$$     val indicesPerPrimitive: Int,
+//$$ ) : SharedIndexBuffer {
+//$$     override fun invoke(vertices: Int): Pair<UGpuBuffer, URenderPass.IndexType> {
+//$$         require(vertices % verticesPerPrimitive == 0)
+//$$         val indices = vertices / verticesPerPrimitive * indicesPerPrimitive
+//$$         val mc = com.mojang.blaze3d.systems.RenderSystem.getSequentialBuffer(drawMode.mcMode)
+//$$         val gpuBuffer = UGraphics.getPlatformAdapter().buffer(mc.getIndexBuffer(indices))
+//$$         val indexType = when (mc.indexType) {
+            //#if MC >= 26.2
+            //$$ com.mojang.blaze3d.IndexType.SHORT -> URenderPass.IndexType.SHORT
+            //$$ com.mojang.blaze3d.IndexType.INT -> URenderPass.IndexType.INT
+            //#else
+            //$$ com.mojang.blaze3d.vertex.VertexFormat.IndexType.SHORT -> URenderPass.IndexType.SHORT
+            //$$ com.mojang.blaze3d.vertex.VertexFormat.IndexType.INT -> URenderPass.IndexType.INT
+            //#endif
+//$$             null -> throw AssertionError()
+//$$         }
+//$$         return Pair(gpuBuffer, indexType)
+//$$     }
+//$$ }
+//#endif

--- a/src/main/kotlin/gg/essential/universal/render/UGpuBuffer.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuBuffer.kt
@@ -1,0 +1,46 @@
+package gg.essential.universal.render
+
+import org.jetbrains.annotations.ApiStatus.NonExtendable
+import java.io.Closeable
+
+@NonExtendable
+sealed interface UGpuBuffer : Closeable {
+    val size: Long
+
+    val isClosed: Boolean
+
+    fun slice(offset: Long = 0, size: Long = this.size - offset) =
+        UGpuBufferSlice(this, offset, size)
+
+    data class Usage(val bits: Int) {
+        operator fun contains(other: Usage): Boolean =
+            (bits and other.bits) == other.bits
+
+        operator fun plus(other: Usage): Usage =
+            Usage(bits or other.bits)
+
+        companion object {
+            val MAP_READ = Usage(1 shl 0)
+            val MAP_WRITE = Usage(1 shl 1)
+            val HINT_CLIENT_STORAGE = Usage(1 shl 2)
+            val COPY_DST = Usage(1 shl 3)
+            val COPY_SRC = Usage(1 shl 4)
+            val VERTEX = Usage(1 shl 5)
+            val INDEX = Usage(1 shl 6)
+            val UNIFORM = Usage(1 shl 7)
+            val UNIFORM_TEXEL_BUFFER = Usage(1 shl 8)
+            val INDIRECT_PARAMETERS = Usage(1 shl 9)
+        }
+    }
+}
+
+data class UGpuBufferSlice(val buffer: UGpuBuffer, val offset: Long, val size: Long) {
+    init {
+        require(offset >= 0) { "offset must not be negative" }
+        require(size >= 0) { "size must not be negative" }
+        require(offset + size <= buffer.size) { "slice (starting at $offset with size $size) points past end of buffer (with size ${buffer.size})" }
+    }
+
+    fun slice(offset: Long = 0, size: Long = this.size - offset) =
+        UGpuBufferSlice(this.buffer, this.offset + offset, size)
+}

--- a/src/main/kotlin/gg/essential/universal/render/UGpuBufferImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuBufferImpl.kt
@@ -1,0 +1,92 @@
+package gg.essential.universal.render
+
+//#if MC >= 1.21.6 && !STANDALONE
+//$$ import com.mojang.blaze3d.buffers.GpuBuffer
+//$$ import java.lang.invoke.MethodHandles
+//$$ import java.lang.reflect.AccessFlag
+//#else
+import org.lwjgl.opengl.GL15
+//#endif
+
+//#if MC >= 1.21.5 && !STANDALONE
+//$$ import net.minecraft.client.gl.GlGpuBuffer
+//#endif
+
+internal class UGpuBufferImpl(
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ val mc: GpuBuffer,
+    //#else
+    val usage: UGpuBuffer.Usage,
+    override val size: Long,
+    val glId: Int,
+    //#endif
+) : UGpuBuffer {
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ val usage: UGpuBuffer.Usage get() = UGpuBuffer.Usage(mc.usage())
+    //$$ override val size: Long get() = mc.size().toLong()
+    //$$ override val isClosed: Boolean get() = mc.isClosed
+    //$$ override fun close() = mc.close()
+    //$$ val glId: Int get() = (mc as GlGpuBuffer).glId
+    //#else
+    override var isClosed = false
+        private set
+
+    override fun close() {
+        if (isClosed) return
+        isClosed = true
+
+        GL15.glDeleteBuffers(glId)
+    }
+    //#endif
+
+    //#if MC == 1.21.5
+    //$$ val mc: GlGpuBuffer
+    //$$     get() = object : GlGpuBuffer(
+    //$$         null,
+    //$$         null,
+    //$$         // MC doesn't use the type and usage in any of the code paths we care about, so we can just pass whatever.
+    //$$         // Though BufferUsage must be one that's not `readable`, otherwise the GlGpuBuffer constructor will
+    //$$         // re-allocate the buffer storage.
+    //$$         com.mojang.blaze3d.buffers.BufferType.VERTICES,
+    //$$         com.mojang.blaze3d.buffers.BufferUsage.DYNAMIC_WRITE,
+    //$$         size.toInt(),
+    //$$         glId,
+    //$$     ) {
+    //$$         // Mark as allocated, otherwise MC may re-allocate the data when `ensureAllocated` is called.
+    //$$         // (I don't think that is ever called on any of the codepaths we care about, but may as well be safe.)
+    //$$         init { hasData = true }
+    //$$     }
+    //#endif
+}
+
+internal val UGpuBuffer.impl: UGpuBufferImpl
+    get() = when (this) { is UGpuBufferImpl -> this }
+
+//#if MC >= 1.21.6 && !STANDALONE
+//$$ internal val UGpuBufferSlice.mc: com.mojang.blaze3d.buffers.GpuBufferSlice
+    //#if MC >= 1.21.11
+    //$$ get() = when (buffer) { is UGpuBufferImpl -> buffer.mc.slice(offset, size) }
+    //#else
+    //$$ get() = when (buffer) { is UGpuBufferImpl -> buffer.mc.slice(offset.toInt(), size.toInt()) }
+    //#endif
+//$$
+//$$ private val glGpuBufferIdFieldAccessor by lazy {
+//$$     val field = GlGpuBuffer::class.java
+        //#if MC >= 26.1
+        //$$ .getDeclaredField("handle")
+        //#else
+        //$$ .declaredFields
+        //$$ .first { field ->
+        //$$     field.type == Int::class.java
+        //$$             && AccessFlag.STATIC !in field.accessFlags()
+        //$$             // looking for a `protected` field, but other mods could access-widen it
+        //$$             && (AccessFlag.PROTECTED in field.accessFlags() || AccessFlag.PUBLIC in field.accessFlags())
+        //$$ }
+        //#endif
+//$$     field.isAccessible = true
+//$$     MethodHandles.lookup().unreflectGetter(field)
+//$$ }
+//$$ private val GlGpuBuffer.glId: Int
+//$$     get() = glGpuBufferIdFieldAccessor.invoke(this) as Int
+//#endif

--- a/src/main/kotlin/gg/essential/universal/render/UGpuBufferImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuBufferImpl.kt
@@ -32,7 +32,10 @@ internal class UGpuBufferImpl(
     override var isClosed = false
         private set
 
+    var mappedCount = 0
+
     override fun close() {
+        if (mappedCount > 0) throw IllegalStateException("Buffer is currently mapped")
         if (isClosed) return
         isClosed = true
 

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -5,6 +5,8 @@ import java.nio.ByteBuffer
 
 @NonExtendable
 sealed interface UGpuDevice {
+    val info: Info
+
     fun createTexture(
         label: String?,
         usage: UGpuTexture.Usage,
@@ -49,4 +51,15 @@ sealed interface UGpuDevice {
     fun createFence(): UGpuFence
 
     fun createRenderPass(descriptor: URenderPassDescriptor): URenderPass
+
+    @NonExtendable
+    interface Info {
+        val isZZeroToOne: Boolean
+        val limits: Limits
+    }
+
+    @NonExtendable
+    interface Limits {
+        fun maxTextureSize(format: UGpuFormat): Int
+    }
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -23,5 +23,10 @@ sealed interface UGpuDevice {
     fun createBuffer(usage: UGpuBuffer.Usage, size: Long): UGpuBuffer
     fun createBuffer(usage: UGpuBuffer.Usage, buffer: ByteBuffer): UGpuBuffer
 
+    fun mapBuffer(gpuBufferSlice: UGpuBufferSlice, read: Boolean, write: Boolean): MappedBuffer
+    interface MappedBuffer : AutoCloseable {
+        val data: ByteBuffer
+    }
+
     fun createFence(): UGpuFence
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -20,6 +20,9 @@ sealed interface UGpuDevice {
         mipLevels: Int = texture.mipLevels,
     ): UGpuTextureView
 
+    fun clearColor(texture: UGpuTexture, red: Float, green: Float, blue: Float, alpha: Float)
+    fun clearDepth(texture: UGpuTexture, depth: Double)
+
     fun createBuffer(usage: UGpuBuffer.Usage, size: Long): UGpuBuffer
     fun createBuffer(usage: UGpuBuffer.Usage, buffer: ByteBuffer): UGpuBuffer
 

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -44,4 +44,6 @@ sealed interface UGpuDevice {
     )
 
     fun createFence(): UGpuFence
+
+    fun createRenderPass(descriptor: URenderPassDescriptor): URenderPass
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -20,5 +20,8 @@ sealed interface UGpuDevice {
         mipLevels: Int = texture.mipLevels,
     ): UGpuTextureView
 
+    fun createBuffer(usage: UGpuBuffer.Usage, size: Long): UGpuBuffer
+    fun createBuffer(usage: UGpuBuffer.Usage, buffer: ByteBuffer): UGpuBuffer
+
     fun createFence(): UGpuFence
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -28,5 +28,20 @@ sealed interface UGpuDevice {
         val data: ByteBuffer
     }
 
+    fun copyBufferToTexture(
+        source: UGpuBufferSlice,
+        sourceX: Int,
+        sourceY: Int,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        destination: UGpuTexture,
+        destinationX: Int,
+        destinationY: Int,
+        copyWidth: Int,
+        copyHeight: Int,
+        mipLevel: Int,
+        arrayLayer: Int,
+    )
+
     fun createFence(): UGpuFence
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDevice.kt
@@ -19,4 +19,6 @@ sealed interface UGpuDevice {
         baseMipLevel: Int = 0,
         mipLevels: Int = texture.mipLevels,
     ): UGpuTextureView
+
+    fun createFence(): UGpuFence
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -4,6 +4,9 @@ import gg.essential.universal.UGraphics
 import java.nio.ByteBuffer
 import kotlin.math.max
 import org.lwjgl.opengl.GL11
+import org.lwjgl.opengl.GL15
+import org.lwjgl.opengl.GL30
+import org.lwjgl.opengl.GL31
 
 //#if STANDALONE
 //$$ import org.lwjgl.opengl.GL20C
@@ -25,6 +28,16 @@ import net.minecraft.client.renderer.GlStateManager
 //#endif
 
 internal object UGpuDeviceImpl : UGpuDevice {
+    //#if MC >= 1.16
+    //$$ val OpenGL31 by lazy { org.lwjgl.opengl.GL.getCapabilities().OpenGL31 }
+    //$$ val OpenGL30 by lazy { org.lwjgl.opengl.GL.getCapabilities().OpenGL30 }
+    //#else
+    val OpenGL31 by lazy { org.lwjgl.opengl.GLContext.getCapabilities().OpenGL31 }
+    val OpenGL30 by lazy { org.lwjgl.opengl.GLContext.getCapabilities().OpenGL30 }
+    //#endif
+
+    private val tmpVao by lazy { GL30.glGenVertexArrays() }
+
     override fun createTexture(
         label: String?,
         usage: UGpuTexture.Usage,
@@ -198,6 +211,83 @@ internal object UGpuDeviceImpl : UGpuDevice {
         val maxMipLevels = log2(max(width, height)) + 1
         require(mipLevels <= maxMipLevels) { "Texture of size ${width}x${height} supports at most $maxMipLevels but $mipLevels were requested" }
     }
+
+    override fun createBuffer(usage: UGpuBuffer.Usage, size: Long): UGpuBuffer {
+        require(size <= Int.MAX_VALUE) { "Sizes greater than Int.MAX_VALUE are not supported" } // due to MC 1.21.6-9
+        //#if MC >= 1.21.11 && !STANDALONE
+        //$$ return UGpuBufferImpl(RenderSystem.getDevice().createBuffer(null, usage.bits, size))
+        //#elseif MC >= 1.21.6 && !STANDALONE
+        //$$ return UGpuBufferImpl(RenderSystem.getDevice().createBuffer(null, usage.bits, size.toInt()))
+        //#else
+        val buffer = UGpuBufferImpl(usage, size, GL15.glGenBuffers())
+        withBufferBound(buffer) { bindTarget ->
+            GL15.glBufferData(bindTarget, size, usage.glUsageHint)
+        }
+        return buffer
+        //#endif
+    }
+
+    override fun createBuffer(usage: UGpuBuffer.Usage, buffer: ByteBuffer): UGpuBuffer {
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ return UGpuBufferImpl(RenderSystem.getDevice().createBuffer(null, usage.bits, buffer))
+        //#else
+        val gpuBuffer = UGpuBufferImpl(usage, buffer.remaining().toLong(), GL15.glGenBuffers())
+        withBufferBound(gpuBuffer) { bindTarget ->
+            GL15.glBufferData(bindTarget, buffer, usage.glUsageHint)
+        }
+        return gpuBuffer
+        //#endif
+    }
+
+    //#if MC < 1.21.6 || STANDALONE
+    private inline fun <T> withBufferBound(gpuBuffer: UGpuBufferImpl, block: (bindTarget: Int) -> T): T {
+        val bindTarget = gpuBuffer.usage.bindTarget
+        val bindTargetBinding = when (bindTarget) {
+            GL15.GL_ARRAY_BUFFER -> GL15.GL_ARRAY_BUFFER_BINDING
+            GL15.GL_ELEMENT_ARRAY_BUFFER -> GL15.GL_ELEMENT_ARRAY_BUFFER_BINDING
+            GL31.GL_UNIFORM_BUFFER -> GL31.GL_UNIFORM_BUFFER_BINDING
+            GL31.GL_COPY_WRITE_BUFFER -> 0x8F37 // GL31.GL_COPY_WRITE_BUFFER_BINDING (missing from LWJGL3 for unknown reason?)
+            else -> throw AssertionError("Unexpected bind target $bindTarget")
+        }
+        val prevVao: Int
+        if (bindTarget == GL15.GL_ELEMENT_ARRAY_BUFFER && OpenGL30) {
+            // Requires VAO, see https://stackoverflow.com/questions/20391921/
+            prevVao = GL11.glGetInteger(GL30.GL_VERTEX_ARRAY_BINDING)
+            GL30.glBindVertexArray(tmpVao)
+        } else {
+            prevVao = 0
+        }
+        val prevBinding = GL11.glGetInteger(bindTargetBinding)
+        GL15.glBindBuffer(bindTarget, gpuBuffer.glId)
+        try {
+            return block(bindTarget)
+        } finally {
+            GL15.glBindBuffer(bindTarget, prevBinding)
+            if (bindTarget == GL15.GL_ELEMENT_ARRAY_BUFFER && OpenGL30) {
+                GL30.glBindVertexArray(prevVao)
+            }
+        }
+    }
+
+    // We'll try to pick an appropriate binding target for our buffers because
+    // > Once created, a named buffer object may be re-bound to any target as often as needed. However, the GL
+    // > implementation may make choices about how to optimize the storage of a buffer object based on its initial
+    // > binding target.
+    private val UGpuBuffer.Usage.bindTarget: Int
+        get() = when {
+            UGpuBuffer.Usage.VERTEX in this -> GL15.GL_ARRAY_BUFFER
+            UGpuBuffer.Usage.INDEX in this -> GL15.GL_ELEMENT_ARRAY_BUFFER
+            UGpuBuffer.Usage.UNIFORM in this -> if (OpenGL31) GL31.GL_UNIFORM_BUFFER else GL15.GL_ARRAY_BUFFER
+            else -> if (OpenGL31) GL31.GL_COPY_WRITE_BUFFER else GL15.GL_ARRAY_BUFFER
+        }
+
+    private val UGpuBuffer.Usage.glUsageHint: Int
+        get() = when {
+            UGpuBuffer.Usage.MAP_WRITE in this -> if (UGpuBuffer.Usage.HINT_CLIENT_STORAGE in this) GL15.GL_STREAM_DRAW else GL15.GL_STATIC_DRAW
+            UGpuBuffer.Usage.MAP_READ in this -> if (UGpuBuffer.Usage.HINT_CLIENT_STORAGE in this) GL15.GL_STREAM_READ else GL15.GL_STATIC_READ
+            else -> GL15.GL_STATIC_DRAW
+        }
+    //#endif
 
     override fun createFence(): UGpuFence {
         return UGpuFenceImpl()

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -198,4 +198,8 @@ internal object UGpuDeviceImpl : UGpuDevice {
         val maxMipLevels = log2(max(width, height)) + 1
         require(mipLevels <= maxMipLevels) { "Texture of size ${width}x${height} supports at most $maxMipLevels but $mipLevels were requested" }
     }
+
+    override fun createFence(): UGpuFence {
+        return UGpuFenceImpl()
+    }
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -4,13 +4,35 @@ import gg.essential.universal.UGraphics
 import java.nio.ByteBuffer
 import kotlin.math.max
 import org.lwjgl.opengl.GL11
+import org.lwjgl.opengl.GL12
 import org.lwjgl.opengl.GL15
+import org.lwjgl.opengl.GL21
 import org.lwjgl.opengl.GL30
 import org.lwjgl.opengl.GL31
 
 //#if STANDALONE
 //$$ import org.lwjgl.opengl.GL20C
 //#else
+
+//#if MC >= 26.2
+//$$ import com.mojang.blaze3d.opengl.GlConst
+//$$ import com.mojang.blaze3d.systems.CommandEncoder
+//$$ import com.mojang.blaze3d.systems.CommandEncoderBackend
+//$$ import com.mojang.blaze3d.systems.GpuDevice
+//$$ import com.mojang.blaze3d.systems.GpuDeviceBackend
+//$$ import com.mojang.blaze3d.vulkan.VulkanBackend
+//$$ import com.mojang.blaze3d.vulkan.VulkanCommandEncoder
+//$$ import com.mojang.blaze3d.vulkan.VulkanDevice
+//$$ import com.mojang.blaze3d.vulkan.VulkanGpuBuffer
+//$$ import com.mojang.blaze3d.vulkan.VulkanGpuTexture
+//$$ import org.lwjgl.system.MemoryStack
+//$$ import org.lwjgl.vulkan.VK10
+//$$ import org.lwjgl.vulkan.VK12
+//$$ import org.lwjgl.vulkan.VkBufferImageCopy
+//$$ import org.lwjgl.vulkan.VkCommandBuffer
+//$$ import java.lang.invoke.MethodHandles
+//#endif
+
 //#if MC >= 1.21.5
 //$$ import com.mojang.blaze3d.textures.TextureFormat
 //$$ import net.minecraft.client.texture.GlTexture
@@ -348,7 +370,156 @@ internal object UGpuDeviceImpl : UGpuDevice {
         }
     //#endif
 
+    override fun copyBufferToTexture(
+        source: UGpuBufferSlice,
+        sourceX: Int,
+        sourceY: Int,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        destination: UGpuTexture,
+        destinationX: Int,
+        destinationY: Int,
+        copyWidth: Int,
+        copyHeight: Int,
+        mipLevel: Int,
+        arrayLayer: Int,
+    ) {
+        val destinationWidth = (destination.width shr mipLevel).coerceAtLeast(1)
+        val destinationHeight = (destination.height shr mipLevel).coerceAtLeast(1)
+        require(!source.buffer.isClosed) { "Source buffer is closed" }
+        require(!destination.isClosed) { "Destination texture is closed" }
+        require(UGpuBuffer.Usage.COPY_SRC in source.buffer.impl.usage) { "Source buffer must have COPY_SRC usage flag" }
+        require(UGpuTexture.Usage.COPY_DST in destination.impl.usage) { "Destination texture must have COPY_DST usage flag" }
+        require(copyWidth >= 0) { "copyWidth must be positive but was $copyWidth" }
+        require(copyHeight >= 0) { "copyHeight must be positive but was $copyHeight" }
+        require(sourceX >= 0) { "sourceX must be positive but was $sourceX" }
+        require(sourceY >= 0) { "sourceY must be positive but was $sourceY" }
+        require(sourceX + copyWidth <= sourceWidth) { "Tried to copy $copyWidth from $sourceX but source is only $sourceWidth wide" }
+        require(sourceY + copyHeight <= sourceHeight) { "Tried to copy $copyHeight from $sourceY but source is only $sourceHeight high" }
+        require(destinationX >= 0) { "destinationX must be positive but was $destinationX" }
+        require(destinationY >= 0) { "destinationY must be positive but was $destinationY" }
+        require(destinationX + copyWidth <= destinationWidth) { "Tried to copy $copyWidth to $destinationX but destination is only $destinationWidth wide" }
+        require(destinationY + copyHeight <= destinationHeight) { "Tried to copy $copyHeight to $destinationY but destination is only $destinationHeight high" }
+        require(mipLevel >= 0) { "mipLevel must not be negative" }
+        require(mipLevel < destination.mipLevels) { "mipLevel is $mipLevel but destination only has ${destination.mipLevels} levels" }
+        require(arrayLayer == 0) { "arrayLayer other than 0 is not yet supported" }
+
+        val format = destination.impl.format
+        require(source.offset % format.componentByteSize == 0L) { "Source buffer offset must be ${format.componentByteSize}-aligned but was ${source.offset}" }
+        val texelByteSize = format.componentCount * format.componentByteSize
+        val texelCopyRange = sourceX + sourceY * sourceWidth.toLong() until(sourceX + copyWidth) + (sourceY + copyHeight - 1) * sourceWidth.toLong()
+        val bytesCopyRange = texelCopyRange.first * texelByteSize .. texelCopyRange.last * texelByteSize
+        require(bytesCopyRange.last < source.size) { "Copy range $bytesCopyRange is out of bounds for $source"}
+
+        if (isVulkan()) {
+            //#if MC >= 26.2 && !STANDALONE
+            //$$ MemoryStack.stackPush().use { stack ->
+            //$$     VK12.vkCmdCopyBufferToImage(
+            //$$         vkCommandBuffer(),
+            //$$         (source.buffer.impl.mc as VulkanGpuBuffer).vkBuffer(),
+            //$$         (destination.impl.mc as VulkanGpuTexture).vkImage(),
+            //$$         1,
+            //$$         VkBufferImageCopy.calloc(1, stack).also { region ->
+            //$$             region.bufferOffset(source.offset + bytesCopyRange.first)
+            //$$             region.bufferRowLength(sourceWidth)
+            //$$             region.bufferImageHeight(sourceHeight)
+            //$$             region.imageSubresource().let { image ->
+            //$$                 image.aspectMask(VK10.VK_IMAGE_ASPECT_COLOR_BIT)
+            //$$                 image.mipLevel(mipLevel)
+            //$$                 image.baseArrayLayer(arrayLayer)
+            //$$                 image.layerCount(1)
+            //$$             }
+            //$$             region.imageOffset().set(destinationX, destinationY, 0)
+            //$$             region.imageExtent().set(copyWidth, copyHeight, 1)
+            //$$         },
+            //$$     )
+            //$$     vkMemoryBarrier(stack)
+            //$$ }
+            //#endif
+        } else {
+            UGraphics.configureTexture(destination.impl.glId) {
+                GL11.glPixelStorei(GL11.GL_UNPACK_ROW_LENGTH, sourceWidth)
+                GL11.glPixelStorei(GL12.GL_UNPACK_IMAGE_HEIGHT, sourceHeight)
+                GL11.glPixelStorei(GL11.GL_UNPACK_SKIP_PIXELS, 0)
+                GL11.glPixelStorei(GL11.GL_UNPACK_SKIP_ROWS, 0)
+                GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, format.componentByteSize)
+
+                GL15.glBindBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, source.buffer.impl.glId)
+
+                GL11.glTexSubImage2D(
+                    GL11.GL_TEXTURE_2D,
+                    mipLevel,
+                    destinationX,
+                    destinationY,
+                    copyWidth,
+                    copyHeight,
+                    //#if MC >= 26.2 && !STANDALONE
+                    //$$ GlConst.toGlExternalId(destination.impl.format.mc),
+                    //$$ GlConst.toGlType(destination.impl.format.mc),
+                    //#else
+                    destination.impl.format.format,
+                    destination.impl.format.type,
+                    //#endif
+                    source.offset + bytesCopyRange.first,
+                )
+
+                GL15.glBindBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, 0)
+
+                // We restore these to defaults as well as to not disturb third-party mods which assume defaults
+                GL11.glPixelStorei(GL11.GL_UNPACK_ROW_LENGTH, 0)
+                GL11.glPixelStorei(GL12.GL_UNPACK_IMAGE_HEIGHT, 0)
+                GL11.glPixelStorei(GL11.GL_UNPACK_SKIP_PIXELS, 0)
+                GL11.glPixelStorei(GL11.GL_UNPACK_SKIP_ROWS, 0)
+                GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 4)
+            }
+        }
+    }
+
     override fun createFence(): UGpuFence {
         return UGpuFenceImpl()
     }
+
+    //#if MC >= 26.2 && !STANDALONE
+    //$$ private val lookup = MethodHandles.lookup()
+    //$$ private val GpuDevice_backend by lazy {
+    //$$     val field = GpuDevice::class.java.getDeclaredField("backend")
+    //$$     field.isAccessible = true
+    //$$     lookup.unreflectGetter(field)
+    //$$ }
+    //$$
+    //$$ fun isVulkan() =
+    //$$     RenderSystem.getDevice()
+    //$$         .let { GpuDevice_backend.invoke(it) as GpuDeviceBackend }
+    //$$         .let { it is VulkanDevice }
+    //$$
+    //$$ private val CommandEncoder_backend by lazy {
+    //$$     val field = CommandEncoder::class.java.getDeclaredField("backend")
+    //$$     field.isAccessible = true
+    //$$     lookup.unreflectGetter(field)
+    //$$ }
+    //$$
+    //$$ private val VulkanCommandEncoder_commandBuffer by lazy {
+    //$$     val method = VulkanCommandEncoder::class.java.getDeclaredMethod("commandBuffer")
+    //$$     method.isAccessible = true
+    //$$     lookup.unreflect(method)
+    //$$ }
+    //$$ private fun vkCommandBuffer(): VkCommandBuffer =
+    //$$     RenderSystem.getDevice()
+    //$$         .createCommandEncoder()
+    //$$         .let { CommandEncoder_backend.invoke(it) as CommandEncoderBackend }
+    //$$         .let { VulkanCommandEncoder_commandBuffer.invoke(it) as VkCommandBuffer }
+    //$$
+    //$$ private val VulkanCommandEncoder_memoryBarrier by lazy {
+    //$$     val method = VulkanCommandEncoder::class.java.getDeclaredMethod("memoryBarrier", MemoryStack::class.java)
+    //$$     method.isAccessible = true
+    //$$     lookup.unreflect(method)
+    //$$ }
+    //$$ private fun vkMemoryBarrier(stack: MemoryStack): Unit =
+    //$$     RenderSystem.getDevice()
+    //$$         .createCommandEncoder()
+    //$$         .let { CommandEncoder_backend.invoke(it) as CommandEncoderBackend }
+    //$$         .let { VulkanCommandEncoder_memoryBarrier.invoke(it, stack); Unit }
+    //#else
+    fun isVulkan() = false
+    //#endif
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -10,6 +10,20 @@ import org.lwjgl.opengl.GL21
 import org.lwjgl.opengl.GL30
 import org.lwjgl.opengl.GL31
 
+//#if MC >= 1.17
+//$$ import org.lwjgl.opengl.GL30.glBindFramebuffer
+//$$ import org.lwjgl.opengl.GL30.glFramebufferTexture2D
+//$$ import org.lwjgl.opengl.GL30.glGenFramebuffers
+//#elseif MC >= 1.14
+//$$ import com.mojang.blaze3d.platform.GlStateManager.bindFramebuffer as glBindFramebuffer
+//$$ import com.mojang.blaze3d.platform.GlStateManager.framebufferTexture2D as glFramebufferTexture2D
+//$$ import com.mojang.blaze3d.platform.GlStateManager.genFramebuffers as glGenFramebuffers
+//#else
+import net.minecraft.client.renderer.OpenGlHelper.glBindFramebuffer
+import net.minecraft.client.renderer.OpenGlHelper.glFramebufferTexture2D
+import net.minecraft.client.renderer.OpenGlHelper.glGenFramebuffers
+//#endif
+
 //#if STANDALONE
 //$$ import org.lwjgl.opengl.GL20C
 //#else
@@ -478,6 +492,97 @@ internal object UGpuDeviceImpl : UGpuDevice {
     override fun createFence(): UGpuFence {
         return UGpuFenceImpl()
     }
+
+    override fun createRenderPass(descriptor: URenderPassDescriptor): URenderPass {
+        return URenderPassImpl(descriptor)
+    }
+
+    //#if MC < 26.2 || STANDALONE
+    private val colorReadFrameBuffer by lazy { glGenFramebuffers() }
+    private val colorWriteFrameBuffer by lazy { glGenFramebuffers() }
+    private val depthReadFrameBuffer by lazy { genDepthOnlyFrameBuffer() }
+    private val depthWriteFrameBuffer by lazy { genDepthOnlyFrameBuffer() }
+    private fun genDepthOnlyFrameBuffer() = glGenFramebuffers().also { id ->
+        val prevDrawFrameBufferBinding = GL11.glGetInteger(GL30.GL_DRAW_FRAMEBUFFER_BINDING)
+        val prevReadFrameBufferBinding = GL11.glGetInteger(GL30.GL_READ_FRAMEBUFFER_BINDING)
+        glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, id)
+        glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, id)
+        // Prior to GL 4.1, read and draw buffers (both!) must be explicitly set to NONE if the framebuffer does not
+        // have a color attachment, otherwise it will not be considered complete and operations on it may error.
+        GL11.glDrawBuffer(GL11.GL_NONE)
+        GL11.glReadBuffer(GL11.GL_NONE)
+        glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, prevDrawFrameBufferBinding)
+        glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, prevReadFrameBufferBinding)
+    }
+
+    inline fun <T> withDrawFramebuffer(color: UGpuTexture?, depth: UGpuTexture?, block: () -> T): T {
+        val prevDrawFrameBufferBinding = GL11.glGetInteger(GL30.GL_DRAW_FRAMEBUFFER_BINDING)
+        glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, if (color == null) depthWriteFrameBuffer else colorWriteFrameBuffer)
+        if (color != null) glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0, GL11.GL_TEXTURE_2D, color.impl.glId, 0)
+        if (depth != null) glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL11.GL_TEXTURE_2D, depth.impl.glId, 0)
+        try {
+            return block()
+        } finally {
+            glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0, GL11.GL_TEXTURE_2D, 0, 0)
+            glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, prevDrawFrameBufferBinding)
+        }
+    }
+    //#endif
+
+    // FIXME 26.2+ doesn't respect `area`; though we also don't yet need it
+    fun clearColor(texture: UGpuTexture, area: URenderPassDescriptor.RenderArea, color: URenderPassDescriptor.ClearColor) {
+        //#if MC >= 26.2 && !STANDALONE
+        //$$ RenderSystem.getDevice().createCommandEncoder()
+        //$$     .clearColorTexture(texture.impl.mc, org.joml.Vector4f(color.red, color.green, color.blue, color.alpha))
+        //#else
+        withDrawFramebuffer(texture, null) {
+            //#if STANDALONE
+            //$$ GL11.glColorMask(true, true, true, true)
+            //#elseif MC >= 26.1
+            //$$ GlStateManager._colorMask(com.mojang.blaze3d.pipeline.ColorTargetState.WRITE_ALL)
+            //#elseif MC >= 1.21.5
+            //$$ GlStateManager._colorMask(true, true, true, true)
+            //#else
+            GlStateManager.colorMask(true, true, true, true)
+            //#endif
+            UGraphics.clearColor(color.red, color.green, color.blue, color.alpha)
+            glClear(GL11.GL_COLOR_BUFFER_BIT, area)
+        }
+        //#endif
+    }
+
+    // FIXME 26.2+ doesn't respect `area`; though we also don't yet need it
+    fun clearDepth(texture: UGpuTexture, area: URenderPassDescriptor.RenderArea, depth: Double) {
+        //#if MC >= 26.2 && !STANDALONE
+        //$$ RenderSystem.getDevice().createCommandEncoder()
+        //$$     .clearDepthTexture(texture.impl.mc, depth)
+        //#else
+        withDrawFramebuffer(null, texture) {
+            //#if STANDALONE
+            //$$ GL11.glDepthMask(true)
+            //#elseif MC >= 1.21.5
+            //$$ GlStateManager._depthMask(true)
+            //#else
+            GlStateManager.depthMask(true)
+            //#endif
+            UGraphics.clearDepth(depth)
+            glClear(GL11.GL_DEPTH_BUFFER_BIT, area)
+        }
+        //#endif
+    }
+
+    //#if MC < 26.2 || STANDALONE
+    private fun glClear(bits: Int, area: URenderPassDescriptor.RenderArea) {
+        val scissorState = ScissorState(true, area.x, area.y, area.width, area.height)
+
+        val prevScissorState = ScissorState.glActive()
+        if (prevScissorState != scissorState) scissorState.glActivate()
+
+        GL11.glClear(bits)
+
+        if (prevScissorState != scissorState) prevScissorState.glActivate()
+    }
+    //#endif
 
     //#if MC >= 26.2 && !STANDALONE
     //$$ private val lookup = MethodHandles.lookup()

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -74,6 +74,62 @@ internal object UGpuDeviceImpl : UGpuDevice {
     val ARB_map_buffer_range by lazy { org.lwjgl.opengl.GLContext.getCapabilities().GL_ARB_map_buffer_range }
     //#endif
 
+    override val info: UGpuDevice.Info = object : UGpuDevice.Info {
+        override val isZZeroToOne: Boolean
+            //#if MC >= 26.2 && !STANDALONE
+            //$$ get() = RenderSystem.getDevice().deviceInfo.isZZeroToOne
+            //#else
+            get() = false
+            //#endif
+
+        override val limits: UGpuDevice.Limits = object : UGpuDevice.Limits {
+            //#if MC < 26.2 || STANDALONE
+            private val maxTextureSize = mutableMapOf<UGpuFormat, Int>()
+            private fun queryMaxTextureSize(format: UGpuFormat): Int {
+                var size = GL11.glGetInteger(GL11.GL_MAX_TEXTURE_SIZE)
+                // While above is what the GPU can address, that may be much larger than what it can actually
+                // allocate, so we'll scan downwards until we find a size that actually works.
+                while (true) {
+                    // As of OpenGL 3.0 the required minimum is 1024, so if we can't even get that, something's
+                    // probably wrong with the format or driver.
+                    // (Technically, since we support OpenGL 2.1 on MC 1.8.9, the minimum required is just 64; but
+                    //  that is completely unreasonable for a full game; and realistically we'll only be running on
+                    //  3.0+ capable hardware anyway.)
+                    if (size < 1024) {
+                        return 1024
+                    }
+                    // PROXY_TEXTURE_2D is a special target which runs all the validation without actually
+                    // allocating a texture. And if that fails, it simply sets all texture parameters to 0
+                    // instead of emitting an error.
+                    GL11.glTexImage2D(
+                        GL11.GL_PROXY_TEXTURE_2D,
+                        0,
+                        format.impl.internalFormat,
+                        size,
+                        size,
+                        0,
+                        format.impl.format,
+                        format.impl.type,
+                        null as ByteBuffer?,
+                    )
+                    val width = GL11.glGetTexLevelParameteri(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH)
+                    if (width != 0) {
+                        return size
+                    }
+                    size = size shr 1
+                }
+            }
+            //#endif
+
+            override fun maxTextureSize(format: UGpuFormat): Int =
+                //#if MC >= 26.2 && !STANDALONE
+                //$$ RenderSystem.getDevice().deviceInfo.limits.maxTextureSizeForFormat(format.impl.mc)
+                //#else
+                maxTextureSize.getOrPut(format) { queryMaxTextureSize(format) }
+                //#endif
+        }
+    }
+
     private val tmpVao by lazy { GL30.glGenVertexArrays() }
 
     override fun createTexture(

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -250,6 +250,20 @@ internal object UGpuDeviceImpl : UGpuDevice {
         require(mipLevels <= maxMipLevels) { "Texture of size ${width}x${height} supports at most $maxMipLevels but $mipLevels were requested" }
     }
 
+    override fun clearColor(texture: UGpuTexture, red: Float, green: Float, blue: Float, alpha: Float) {
+        require(UGpuTexture.Usage.COPY_DST in texture.impl.usage) { "Texture must have COPY_DST usage flag" }
+        clearColor(
+            texture,
+            URenderPassDescriptor.RenderArea(0, 0, texture.width, texture.height),
+            URenderPassDescriptor.ClearColor(red, green, blue, alpha),
+        )
+    }
+
+    override fun clearDepth(texture: UGpuTexture, depth: Double) {
+        require(UGpuTexture.Usage.COPY_DST in texture.impl.usage) { "Texture must have COPY_DST usage flag" }
+        clearDepth(texture, URenderPassDescriptor.RenderArea(0, 0, texture.width, texture.height), depth)
+    }
+
     override fun createBuffer(usage: UGpuBuffer.Usage, size: Long): UGpuBuffer {
         require(size <= Int.MAX_VALUE) { "Sizes greater than Int.MAX_VALUE are not supported" } // due to MC 1.21.6-9
         //#if MC >= 1.21.11 && !STANDALONE

--- a/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuDeviceImpl.kt
@@ -31,9 +31,11 @@ internal object UGpuDeviceImpl : UGpuDevice {
     //#if MC >= 1.16
     //$$ val OpenGL31 by lazy { org.lwjgl.opengl.GL.getCapabilities().OpenGL31 }
     //$$ val OpenGL30 by lazy { org.lwjgl.opengl.GL.getCapabilities().OpenGL30 }
+    //$$ val ARB_map_buffer_range by lazy { org.lwjgl.opengl.GL.getCapabilities().GL_ARB_map_buffer_range }
     //#else
     val OpenGL31 by lazy { org.lwjgl.opengl.GLContext.getCapabilities().OpenGL31 }
     val OpenGL30 by lazy { org.lwjgl.opengl.GLContext.getCapabilities().OpenGL30 }
+    val ARB_map_buffer_range by lazy { org.lwjgl.opengl.GLContext.getCapabilities().GL_ARB_map_buffer_range }
     //#endif
 
     private val tmpVao by lazy { GL30.glGenVertexArrays() }
@@ -236,6 +238,63 @@ internal object UGpuDeviceImpl : UGpuDevice {
             GL15.glBufferData(bindTarget, buffer, usage.glUsageHint)
         }
         return gpuBuffer
+        //#endif
+    }
+
+    override fun mapBuffer(gpuBufferSlice: UGpuBufferSlice, read: Boolean, write: Boolean): UGpuDevice.MappedBuffer {
+        check(!gpuBufferSlice.buffer.isClosed) { "Buffer is closed" }
+        if (read) require(UGpuBuffer.Usage.MAP_READ in gpuBufferSlice.buffer.impl.usage) { "Buffer must have MAP_READ usage flag" }
+        if (write) require(UGpuBuffer.Usage.MAP_WRITE in gpuBufferSlice.buffer.impl.usage) { "Buffer must have MAP_WRITE usage flag" }
+
+        require(gpuBufferSlice.offset + gpuBufferSlice.size <= Int.MAX_VALUE) { "Slices further than Int.MAX_VALUE into the buffer are not supported" } // due to pre-GL30 fallback path
+
+        //#if MC >= 1.21.6 && !STANDALONE
+        //#if MC >= 26.2
+        //$$ val view = gpuBufferSlice.mc.map(read, write)
+        //#else
+        //$$ val view = RenderSystem.getDevice().createCommandEncoder().mapBuffer(gpuBufferSlice.mc, read, write)
+        //#endif
+        //$$ return object : UGpuDevice.MappedBuffer {
+        //$$     override val data: ByteBuffer = view.data()
+        //$$     override fun close() = view.close()
+        //$$ }
+        //#else
+        val mapBufferRange = OpenGL30 || ARB_map_buffer_range
+        val access = when {
+            read && write -> if (mapBufferRange) GL30.GL_MAP_READ_BIT + GL30.GL_MAP_WRITE_BIT else GL15.GL_READ_WRITE
+            read -> if (mapBufferRange) GL30.GL_MAP_READ_BIT else GL15.GL_READ_ONLY
+            write -> if (mapBufferRange) GL30.GL_MAP_WRITE_BIT else GL15.GL_WRITE_ONLY
+            else -> throw IllegalArgumentException("At least one of `read` or `write` must be true")
+        }
+        val buffer = withBufferBound(gpuBufferSlice.buffer.impl) { bindTarget ->
+            if (mapBufferRange) {
+                GL30.glMapBufferRange(bindTarget, gpuBufferSlice.offset, gpuBufferSlice.size, access, null)
+            } else {
+                @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS") // old_buffer may be null according to javadocs
+                val fullBuf = GL15.glMapBuffer(bindTarget, access, gpuBufferSlice.offset + gpuBufferSlice.size, null)
+                if (gpuBufferSlice.offset > 0) {
+                    fullBuf?.position(gpuBufferSlice.offset.toInt())
+                    fullBuf?.slice()
+                } else {
+                    fullBuf
+                }
+            }
+        } ?: throw IllegalStateException("Failed to map buffer")
+        gpuBufferSlice.buffer.impl.mappedCount++
+        return object : UGpuDevice.MappedBuffer {
+            override val data: ByteBuffer = buffer
+
+            var closed = false
+
+            override fun close() {
+                if (closed) return
+                closed = true
+                gpuBufferSlice.buffer.impl.mappedCount--
+                withBufferBound(gpuBufferSlice.buffer.impl) { bindTarget ->
+                    GL15.glUnmapBuffer(bindTarget)
+                }
+            }
+        }
         //#endif
     }
 

--- a/src/main/kotlin/gg/essential/universal/render/UGpuFence.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuFence.kt
@@ -1,0 +1,17 @@
+package gg.essential.universal.render
+
+import org.jetbrains.annotations.ApiStatus.NonExtendable
+
+@NonExtendable
+interface UGpuFence : AutoCloseable {
+    /**
+     * Waits for this fence to be completed.
+     * Waits at most [timeoutNs] nanoseconds. Returns `true` when the fence was completed, `false` when the timeout has
+     * expired.
+     * When [timeoutNs] is zero, returns the state of the fence immediately, without blocking.
+     *
+     * Note that a fence cannot be blocked on until the frame it was created in has been submitted.
+     * As of 26.2, such a call will throw an exception. On older version it depends on the OpenGL implementation.
+     */
+    fun awaitCompletion(timeoutNs: Long): Boolean
+}

--- a/src/main/kotlin/gg/essential/universal/render/UGpuFenceImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuFenceImpl.kt
@@ -1,0 +1,72 @@
+// MC < 26.2
+package gg.essential.universal.render
+
+import org.lwjgl.opengl.ARBSync
+import org.lwjgl.opengl.GL11
+import org.lwjgl.opengl.GL32
+import org.lwjgl.opengl.GL32.GL_ALREADY_SIGNALED
+import org.lwjgl.opengl.GL32.GL_CONDITION_SATISFIED
+import org.lwjgl.opengl.GL32.GL_TIMEOUT_EXPIRED
+import org.lwjgl.opengl.GL32.GL_WAIT_FAILED
+
+//#if MC >= 1.14
+//$$ typealias GLSync = Long
+//#else
+import org.lwjgl.opengl.GLSync
+//#endif
+
+internal class UGpuFenceImpl : UGpuFence {
+    private var glId: GLSync? = glFenceSync(GL32.GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+
+    override fun awaitCompletion(timeoutNs: Long): Boolean {
+        val glId = glId ?: return true
+
+        return when (val result = glClientWaitSync(glId, 0, timeoutNs)) {
+            GL_ALREADY_SIGNALED -> true
+            GL_TIMEOUT_EXPIRED -> false
+            GL_CONDITION_SATISFIED -> true
+            GL_WAIT_FAILED -> throw RuntimeException("glClientWaitSync returned GL_WAIT_FAILED: " + GL11.glGetError())
+            else -> throw AssertionError("glClientWaitSync returned unexpected value $result")
+        }
+    }
+
+    override fun close() {
+        glId?.let { glDeleteSync(it) }
+        glId = null
+    }
+}
+
+private fun capabilities() =
+    //#if MC >= 1.14
+    //$$ org.lwjgl.opengl.GL.getCapabilities()
+    //#else
+    org.lwjgl.opengl.GLContext.getCapabilities()
+    //#endif
+
+private fun glFenceSync(condition: Int, flags: Int): GLSync? {
+    return when {
+        capabilities().OpenGL32 -> GL32.glFenceSync(condition, flags)
+            //#if MC < 1.14
+            .takeIf { it.isValid }
+            //#endif
+        capabilities().GL_ARB_sync -> ARBSync.glFenceSync(condition, flags)
+            //#if MC < 1.14
+            .takeIf { it.isValid }
+            //#endif
+        else -> null
+    }
+}
+private fun glDeleteSync(id: GLSync) {
+    when {
+        capabilities().OpenGL32 -> GL32.glDeleteSync(id)
+        capabilities().GL_ARB_sync -> ARBSync.glDeleteSync(id)
+        else -> {}
+    }
+}
+private fun glClientWaitSync(id: GLSync, flags: Int, timeoutNs: Long): Int {
+    return when {
+        capabilities().OpenGL32 -> GL32.glClientWaitSync(id, flags, timeoutNs)
+        capabilities().GL_ARB_sync -> ARBSync.glClientWaitSync(id, flags, timeoutNs)
+        else -> GL_ALREADY_SIGNALED
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/render/UGpuPlatformAdapter.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuPlatformAdapter.kt
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.ApiStatus.NonExtendable
 //$$ import com.mojang.blaze3d.GpuFormat
 //#endif
 //#if MC >= 1.21.6
+//$$ import com.mojang.blaze3d.buffers.GpuBuffer
+//$$ import com.mojang.blaze3d.buffers.GpuBufferSlice
 //$$ import com.mojang.blaze3d.textures.GpuTextureView
 //#endif
 //#if MC >= 1.21.5
@@ -38,5 +40,18 @@ sealed interface UGpuPlatformAdapter {
     //#if MC >= 1.21.6 && !STANDALONE
     //$$ fun textureView(textureView: GpuTextureView): UGpuTextureView
     //$$ fun textureView(textureView: UGpuTextureView): GpuTextureView
+    //#endif
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ fun buffer(buffer: GpuBuffer): UGpuBuffer
+    //$$ fun buffer(buffer: UGpuBuffer): GpuBuffer
+    //#else
+    fun buffer(glId: Int, usage: UGpuBuffer.Usage, size: Long): UGpuBuffer
+    fun buffer(buffer: UGpuBuffer): Int
+    //#endif
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ fun bufferSlice(buffer: GpuBufferSlice): UGpuBufferSlice
+    //$$ fun bufferSlice(buffer: UGpuBufferSlice): GpuBufferSlice
     //#endif
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuPlatformAdapterImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuPlatformAdapterImpl.kt
@@ -7,6 +7,8 @@ import org.lwjgl.opengl.GL14
 //#if STANDALONE
 //#else
 //#if MC >= 1.21.6
+//$$ import com.mojang.blaze3d.buffers.GpuBuffer
+//$$ import com.mojang.blaze3d.buffers.GpuBufferSlice
 //$$ import com.mojang.blaze3d.textures.GpuTextureView
 //#endif
 //#if MC >= 1.21.5
@@ -83,5 +85,24 @@ internal object UGpuPlatformAdapterImpl : UGpuPlatformAdapter {
             //#endif
     //$$ override fun textureView(textureView: UGpuTextureView): GpuTextureView =
     //$$     textureView.impl.mc
+    //#endif
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ override fun buffer(buffer: GpuBuffer): UGpuBufferImpl =
+    //$$     UGpuBufferImpl(buffer)
+    //$$ override fun buffer(buffer: UGpuBuffer): GpuBuffer =
+    //$$     buffer.impl.mc
+    //#else
+    override fun buffer(glId: Int, usage: UGpuBuffer.Usage, size: Long): UGpuBufferImpl =
+        UGpuBufferImpl(usage, size, glId)
+    override fun buffer(buffer: UGpuBuffer): Int =
+        buffer.impl.glId
+    //#endif
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ override fun bufferSlice(buffer: GpuBufferSlice): UGpuBufferSlice =
+    //$$     UGpuBufferSlice(buffer(buffer.buffer), buffer.offset.toLong(), buffer.length.toLong())
+    //$$ override fun bufferSlice(buffer: UGpuBufferSlice): GpuBufferSlice =
+    //$$     buffer.mc
     //#endif
 }

--- a/src/main/kotlin/gg/essential/universal/render/UGpuTextureImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/UGpuTextureImpl.kt
@@ -45,6 +45,24 @@ internal data class UGpuFormatImpl(
             else -> false
         }
         //#endif
+    val componentByteSize: Int
+        //#if MC >= 26.2 && !STANDALONE
+        //$$ get() = mc.componentType().byteSize()
+        //#else
+        get() = when (type) {
+            GL11.GL_BYTE, GL11.GL_UNSIGNED_BYTE -> 1
+            else -> throw UnsupportedOperationException("Format $this not yet supported (or invalid).")
+        }
+        //#endif
+    val componentCount: Int
+        //#if MC >= 26.2 && !STANDALONE
+        //$$ get() = mc.componentCount()
+        //#else
+        get() = when (format) {
+            GL11.GL_RGBA -> 4
+            else -> throw UnsupportedOperationException("Format $this not yet supported (or invalid).")
+        }
+        //#endif
 }
 
 internal class UGpuTextureImpl(
@@ -78,6 +96,7 @@ internal class UGpuTextureImpl(
     //$$ override val width: Int get() = mc.getWidth(0)
     //$$ override val height: Int get() = mc.getHeight(0)
     //$$ override val mipLevels: Int get() = mc.mipLevels
+    //$$ val glId: Int get() = (mc as net.minecraft.client.texture.GlTexture).glId
     //#endif
 
     //#if MC >= 1.21.6 && !STANDALONE

--- a/src/main/kotlin/gg/essential/universal/render/URenderPass.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPass.kt
@@ -1,0 +1,30 @@
+package gg.essential.universal.render
+
+import org.jetbrains.annotations.ApiStatus
+
+@ApiStatus.NonExtendable
+interface URenderPass : AutoCloseable {
+    fun scissor(x: Int, y: Int, width: Int, height: Int)
+
+    fun pipeline(pipeline: URenderPipeline)
+    // Note: Currently only slot 0 is supported
+    fun vertexBuffer(slot: Int, buffer: UGpuBufferSlice)
+    fun indexBuffer(buffer: UGpuBuffer, type: IndexType)
+    fun texture(name: String, textureView: UGpuTextureView, sampler: UGpuSampler)
+    fun uniform(name: String, vararg values: Float)
+    fun uniform(name: String, vararg values: Int)
+    fun uniform(name: String, buffer: UGpuBufferSlice) // Note: Currently only supported on 1.21.6+
+
+    fun projectionMatrix(matrix: FloatArray)
+    fun modelViewMatrix(matrix: FloatArray)
+
+    // Note: `instanceCount`, `firstVertex`, `firstInstance` are not yet universally supported
+    fun draw(vertexCount: Int, instanceCount: Int = 1, firstVertex: Int = 0, firstInstance: Int = 0)
+    // Note: `instanceCount`, `firstIndex`, `vertexOffset`, `firstInstance` are not yet universally supported
+    fun drawIndexed(indexCount: Int, instanceCount: Int = 1, firstIndex: Int = 0, vertexOffset: Int = 0, firstInstance: Int = 0)
+
+    enum class IndexType {
+        SHORT,
+        INT,
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/render/URenderPassDescriptor.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPassDescriptor.kt
@@ -1,0 +1,51 @@
+package gg.essential.universal.render
+
+import java.lang.IllegalStateException
+import java.util.function.Supplier
+
+class URenderPassDescriptor(
+    internal val label: Supplier<String>,
+) {
+    internal val colorAttachments = mutableListOf<Pair<UGpuTextureView, ClearColor?>>()
+    internal var depthAttachment: Pair<UGpuTextureView, Double?>? = null
+    internal var renderArea: RenderArea? = null
+
+    fun withColorAttachment(textureView: UGpuTextureView, clearColor: ClearColor? = null) = apply {
+        check(colorAttachments.isEmpty()) { "Multiple color attachments are not yet supported." }
+        check(textureView.baseMipLevel == 0 && textureView.mipLevels == 1) { "Rendering to mipLevel other than 0 is not yet supported." }
+        colorAttachments.add(Pair(textureView, clearColor))
+    }
+
+    fun withDepthAttachment(textureView: UGpuTextureView, clearDepth: Double? = null) = apply {
+        check(textureView.baseMipLevel == 0 && textureView.mipLevels == 1) { "Rendering to mipLevel other than 0 is not yet supported." }
+        depthAttachment = Pair(textureView, clearDepth)
+    }
+
+    fun withRenderArea(renderArea: RenderArea) = apply {
+        this.renderArea = renderArea
+    }
+
+    internal fun outputSize(): RenderArea {
+        val textureView = colorAttachments.firstNotNullOfOrNull { it.first } ?: depthAttachment?.first
+        if (textureView == null) {
+            throw IllegalStateException("Neither color nor depth attachments have been set.")
+        }
+        val width = textureView.texture.width shr textureView.baseMipLevel
+        val height = textureView.texture.height shr textureView.baseMipLevel
+        return RenderArea(0, 0, width, height)
+    }
+
+    data class ClearColor(
+        val red: Float,
+        val green: Float,
+        val blue: Float,
+        val alpha: Float,
+    )
+
+    data class RenderArea(
+        val x: Int,
+        val y: Int,
+        val width: Int,
+        val height: Int,
+    )
+}

--- a/src/main/kotlin/gg/essential/universal/render/URenderPassImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPassImpl.kt
@@ -234,6 +234,13 @@ internal class URenderPassImpl(val descriptor: URenderPassDescriptor) : URenderP
         this.pipeline = pipeline
     }
 
+    //#if MC < 26.2
+    /** Skips the [URenderPipeline.wantsDepthTexture] check where it is safe to do so. */
+    internal fun pipelineUnchecked(pipeline: URenderPipeline) {
+        this.pipeline = pipeline
+    }
+    //#endif
+
     override fun vertexBuffer(slot: Int, buffer: UGpuBufferSlice) {
         require(slot == 0) { "Slots other than 0 are not yet supported" }
         require(buffer.offset == 0L) { "Buffer offsets are not yet supported" }

--- a/src/main/kotlin/gg/essential/universal/render/URenderPassImpl.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPassImpl.kt
@@ -1,0 +1,761 @@
+package gg.essential.universal.render
+
+import gg.essential.universal.UGraphics
+import org.lwjgl.opengl.GL11
+import org.lwjgl.opengl.GL15
+import org.lwjgl.opengl.GL20
+import org.lwjgl.opengl.GL30
+import java.lang.ClassCastException
+import java.lang.IllegalStateException
+
+//#if MC>=11700
+//$$ import org.lwjgl.opengl.GL30.glBindFramebuffer
+//$$ import org.lwjgl.opengl.GL30.glFramebufferTexture2D
+//$$ import org.lwjgl.opengl.GL30.glGenFramebuffers
+//#elseif MC>=11400
+//$$ import com.mojang.blaze3d.platform.GlStateManager.bindFramebuffer as glBindFramebuffer
+//$$ import com.mojang.blaze3d.platform.GlStateManager.framebufferTexture2D as glFramebufferTexture2D
+//$$ import com.mojang.blaze3d.platform.GlStateManager.genFramebuffers as glGenFramebuffers
+//#else
+import net.minecraft.client.renderer.OpenGlHelper.glBindFramebuffer
+import net.minecraft.client.renderer.OpenGlHelper.glFramebufferTexture2D
+import net.minecraft.client.renderer.OpenGlHelper.glGenFramebuffers
+//#endif
+
+//#if STANDALONE
+//$$ import gg.essential.universal.standalone.render.VertexFormat
+//#else
+import net.minecraft.client.renderer.vertex.VertexFormat
+import net.minecraft.client.renderer.vertex.VertexFormatElement
+
+//#if MC >= 1.21.6
+//$$ import com.mojang.blaze3d.buffers.GpuBuffer
+//$$ import com.mojang.blaze3d.buffers.GpuBufferSlice
+//$$ import net.minecraft.client.gl.DynamicUniforms
+//$$ import org.lwjgl.system.MemoryStack
+//#endif
+
+//#if MC >= 1.21.5
+//$$ import com.mojang.blaze3d.systems.RenderPass
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//$$ import net.minecraft.client.texture.GlTexture
+//#if MC >= 26.2
+//$$ import java.util.Optional
+//#else
+//$$ import java.util.OptionalInt
+//#endif
+//$$ import java.util.OptionalDouble
+//#endif
+
+//#if MC == 1.21.5
+//$$ import net.minecraft.client.gl.GlUniform
+//$$ import net.minecraft.client.gl.ShaderProgram
+//#endif
+
+//#if MC >= 1.17
+//#if MC < 1.21.5
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//#endif
+//#else
+import org.lwjgl.opengl.GL13
+import net.minecraft.client.renderer.GlStateManager
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+//#endif
+//#endif
+
+internal class URenderPassImpl(val descriptor: URenderPassDescriptor) : URenderPass {
+    init {
+        if (active) throw IllegalStateException("Must close previous RenderPass before opening new one.")
+        active = true
+
+        check(descriptor.colorAttachments.isNotEmpty()) { "Zero color attachments are not yet supported." }
+    }
+
+    private val outputSize = descriptor.outputSize()
+    private val renderArea = descriptor.renderArea ?: outputSize
+
+    //#if MC >= 1.21.5 && !STANDALONE
+    //$$ private val mc: RenderPass
+    //#else
+    private val prevVao: Int
+    private val prevViewport = ViewportState.active()
+    private var currViewport = prevViewport
+    private val prevDrawFrameBufferBinding = GL11.glGetInteger(GL30.GL_DRAW_FRAMEBUFFER_BINDING)
+    private val prevReadFrameBufferBinding = GL11.glGetInteger(GL30.GL_READ_FRAMEBUFFER_BINDING)
+    private val prevGlState = ManagedGlState.active()
+    private val currGlState = ManagedGlState(prevGlState)
+    private var prevScissor: ScissorState = ScissorState.active()
+    private var currScissor: ScissorState = prevScissor
+    private var currPipeline: URenderPipeline? = null
+    //#endif
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ private val tmpBuffers = mutableListOf<GpuBuffer>()
+    //#endif
+
+    init {
+        // Cleanup global MC state
+        //#if MC >= 1.17 && MC < 1.21.5
+        //$$ net.minecraft.client.render.BufferRenderer.unbindAll()
+        //#endif
+
+        // Clear texture before render pass
+        //#if MC >= 26.2 && !STANDALONE
+        //$$ // Done by `createRenderPass` below
+        //#else
+        for ((textureView, clearColor) in descriptor.colorAttachments) {
+            if (clearColor != null) {
+                UGpuDeviceImpl.clearColor(textureView.texture, renderArea, clearColor)
+            }
+        }
+        descriptor.depthAttachment?.let { (textureView, clearDepth) ->
+            if (clearDepth != null) {
+                UGpuDeviceImpl.clearDepth(textureView.texture, renderArea, clearDepth)
+            }
+        }
+        //#endif
+
+        // Setup render pass
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ mc = RenderSystem.getDevice()
+        //$$     .createCommandEncoder()
+        //$$     .createRenderPass(
+                //#if MC >= 1.21.6
+                //$$ descriptor.label,
+                //#endif
+                //#if MC >= 1.21.6
+                //$$ descriptor.colorAttachments.single().first.impl.mc,
+                //#else
+                //$$ descriptor.colorAttachments.single().first.texture.impl.mc,
+                //#endif
+                //#if MC >= 26.2
+                //$$ descriptor.colorAttachments.single().second?.let { Optional.of(org.joml.Vector4f(it.red, it.green, it.blue, it.alpha)) } ?: Optional.empty(),
+                //#else
+                //$$ OptionalInt.empty(),
+                //#endif
+                //#if MC >= 1.21.6
+                //$$ descriptor.depthAttachment?.first?.impl?.mc,
+                //#else
+                //$$ descriptor.depthAttachment?.first?.texture?.impl?.mc,
+                //#endif
+                //#if MC >= 26.2
+                //$$ descriptor.depthAttachment?.second?.let { OptionalDouble.of(it) } ?: OptionalDouble.empty(),
+                //#else
+                //$$ OptionalDouble.empty(),
+                //#endif
+        //$$     )
+        //#else
+        glBindFramebuffer(GL30.GL_FRAMEBUFFER, framebuffer)
+        for ((index, attachment) in descriptor.colorAttachments.withIndex()) {
+            val (textureView, _) = attachment
+            glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0 + index, GL11.GL_TEXTURE_2D, textureView.texture.impl.glId, textureView.baseMipLevel)
+        }
+        descriptor.depthAttachment?.let { (textureView, _) ->
+            glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL11.GL_TEXTURE_2D, textureView.texture.impl.glId, textureView.baseMipLevel)
+        }
+        // Prior to GL 4.1, read and draw buffers (both!) must be explicitly set to NONE if the framebuffer does not
+        // have a color attachment, otherwise it will not be considered complete and operations on it may error.
+        GL11.glDrawBuffer(if (descriptor.colorAttachments.isEmpty()) GL11.GL_NONE else GL30.GL_COLOR_ATTACHMENT0)
+        GL11.glReadBuffer(if (descriptor.colorAttachments.isEmpty()) GL11.GL_NONE else GL30.GL_COLOR_ATTACHMENT0)
+
+        val viewport = ViewportState(outputSize.x, outputSize.y, outputSize.width, outputSize.height)
+        if (viewport != currViewport) {
+            viewport.activate()
+            currViewport = viewport
+        }
+
+        if (UGpuDeviceImpl.OpenGL30) {
+            prevVao = GL11.glGetInteger(GL30.GL_VERTEX_ARRAY_BINDING)
+            GL30.glBindVertexArray(vao)
+        } else {
+            prevVao = 0
+        }
+        //#endif
+    }
+
+    override fun close() {
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ mc.close()
+        //#else
+        currPipeline?.unbind()
+        if (prevScissor != currScissor) prevScissor.activate()
+        prevGlState.activate(currGlState, prevGlState, true)
+        for (index in descriptor.colorAttachments.indices) {
+            glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0 + index, GL11.GL_TEXTURE_2D, 0, 0)
+        }
+        descriptor.depthAttachment?.let { _ ->
+            glFramebufferTexture2D(GL30.GL_DRAW_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL11.GL_TEXTURE_2D, 0, 0)
+        }
+        glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, prevDrawFrameBufferBinding)
+        glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, prevReadFrameBufferBinding)
+        if (prevViewport != currViewport) prevViewport.activate()
+        if (UGpuDeviceImpl.OpenGL30) {
+            GL30.glBindVertexArray(prevVao)
+        }
+        //#endif
+
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ tmpBuffers.forEach { it.close() }
+        //#endif
+
+        active = false
+    }
+
+    private var scissor: ScissorState = ScissorState(true, renderArea.x, renderArea.y, renderArea.width, renderArea.height)
+    private var pipeline: URenderPipeline? = null
+    private var vertexBuffer: UGpuBufferSlice? = null
+    private var indexBuffer: Pair<UGpuBuffer, URenderPass.IndexType>? = null
+    private val textures = mutableMapOf<String, Pair<UGpuTextureView, UGpuSampler>>()
+    private val uniforms = mutableMapOf<String, Any>()
+    private var projectionMatrix = IDENTITY_MAT4
+    private var modelViewMatrix = IDENTITY_MAT4
+
+    private var projectionUboDirty = true
+    private var dynamicTransformsUboDirty = true
+
+    override fun scissor(x: Int, y: Int, width: Int, height: Int) {
+        require(width > 0) { "Scissor width must be positive but was $width" }
+        require(height > 0) { "Scissor height must be positive but was $height" }
+        val scissor = ScissorState(true, x, y, width, height)
+        val boundedScissor = scissor.coerceIn(renderArea.x, renderArea.y, renderArea.width, renderArea.height)
+        require(scissor == boundedScissor) { "$scissor is out of bounds for render area $renderArea" }
+        this.scissor = scissor
+    }
+
+    override fun pipeline(pipeline: URenderPipeline) {
+        // This check exists because on Vulkan trying to use such a pipeline when no depth texture is provided will
+        // result in undefined behavior (likely segfault).
+        // We apply the check to all versions so one gets notified of one's incorrect code even if one primarily tests
+        // on older versions.
+        if (pipeline.wantsDepthTexture) {
+            require(descriptor.depthAttachment != null) { "Pipeline requires depth attachment but this render pass does not have one." }
+        }
+        this.pipeline = pipeline
+    }
+
+    override fun vertexBuffer(slot: Int, buffer: UGpuBufferSlice) {
+        require(slot == 0) { "Slots other than 0 are not yet supported" }
+        require(buffer.offset == 0L) { "Buffer offsets are not yet supported" }
+        this.vertexBuffer = buffer
+    }
+
+    override fun indexBuffer(buffer: UGpuBuffer, type: URenderPass.IndexType) {
+        this.indexBuffer = Pair(buffer, type)
+    }
+
+    override fun texture(name: String, textureView: UGpuTextureView, sampler: UGpuSampler) {
+        require(textureView.baseMipLevel == 0) { "baseMipLevel other than 0 is not yet supported" }
+        textures[name] = Pair(textureView, sampler)
+    }
+
+    override fun uniform(name: String, values: FloatArray) {
+        uniforms[name] = values
+    }
+
+    override fun uniform(name: String, values: IntArray) {
+        uniforms[name] = values
+    }
+
+    override fun uniform(name: String, buffer: UGpuBufferSlice) {
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ uniforms[name] = buffer.mc
+        //#else
+        throw UnsupportedOperationException("UBOs are currently only supported on 1.21.6+")
+        //#endif
+    }
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ private fun allocUBO(name: String, values: FloatArray) =
+    //$$     MemoryStack.stackPush().use { stack ->
+    //$$         val byteBuf = stack.malloc(values.size * Float.SIZE_BYTES)
+    //$$         values.forEach { byteBuf.putFloat(it) }
+    //$$         byteBuf.flip()
+    //$$         RenderSystem.getDevice().createBuffer({ "$name UBO" }, GpuBuffer.USAGE_UNIFORM, byteBuf)
+    //$$     }.also { tmpBuffers.add(it) }
+    //$$ private fun allocUBO(name: String, values: IntArray) =
+    //$$     MemoryStack.stackPush().use { stack ->
+    //$$         val byteBuf = stack.malloc(values.size * Int.SIZE_BYTES)
+    //$$         values.forEach { byteBuf.putInt(it) }
+    //$$         byteBuf.flip()
+    //$$         RenderSystem.getDevice().createBuffer({ "$name UBO" }, GpuBuffer.USAGE_UNIFORM, byteBuf)
+    //$$     }.also { tmpBuffers.add(it) }
+    //#endif
+
+    override fun projectionMatrix(matrix: FloatArray) {
+        require(matrix.size == 16) { "Matrix must have 16 entries (4x4)"}
+        if (matrix.contentEquals(projectionMatrix)) return
+        projectionMatrix = matrix.copyOf()
+        projectionUboDirty = true
+    }
+
+    override fun modelViewMatrix(matrix: FloatArray) {
+        require(matrix.size == 16) { "Matrix must have 16 entries (4x4)"}
+        if (matrix.contentEquals(modelViewMatrix)) return
+        modelViewMatrix = matrix.copyOf()
+        dynamicTransformsUboDirty = true
+    }
+
+    override fun draw(
+        vertexCount: Int,
+        instanceCount: Int,
+        firstVertex: Int,
+        firstInstance: Int,
+    ) {
+        require(instanceCount == 1) { "instanceCount is not yet supported" }
+        require(firstInstance == 0) { "firstInstance is not yet supported" }
+
+        val pipeline = pipeline ?: throw IllegalStateException("No pipeline has been set")
+        val vertexBuffer = vertexBuffer ?: throw IllegalStateException("No vertex buffer has been set")
+
+        check(!vertexBuffer.buffer.isClosed) { "Vertex buffer has already been closed." }
+
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ drawCall(pipeline) {
+            //#if MC >= 26.2
+            //$$ mc.setVertexBuffer(0, vertexBuffer.mc)
+            //#else
+            //$$ mc.setVertexBuffer(0, vertexBuffer.buffer.impl.mc)
+            //#endif
+            //#if MC >= 26.2
+            //$$ mc.draw(vertexCount, instanceCount, firstVertex, firstInstance)
+            //#else
+            //$$ mc.draw(firstVertex, vertexCount)
+            //#endif
+        //$$ }
+        //#else
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, vertexBuffer.buffer.impl.glId)
+        drawCall(pipeline) {
+            GL11.glDrawArrays(pipeline.drawMode.actualGlMode, firstVertex, vertexCount)
+        }
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0)
+        //#endif
+    }
+
+    override fun drawIndexed(
+        indexCount: Int,
+        instanceCount: Int,
+        firstIndex: Int,
+        vertexOffset: Int,
+        firstInstance: Int,
+    ) {
+        require(instanceCount == 1) { "instanceCount is not yet supported" }
+        require(vertexOffset == 0) { "vertexOffset is not yet supported" }
+        require(firstInstance == 0) { "firstInstance is not yet supported" }
+
+        val pipeline = pipeline ?: throw IllegalStateException("No pipeline has been set")
+        val vertexBuffer = vertexBuffer ?: throw IllegalStateException("No vertex buffer has been set")
+        val (indexBuffer, indexType) = indexBuffer ?: throw IllegalStateException("No index buffer has been set")
+
+        check(!vertexBuffer.buffer.isClosed) { "Vertex buffer has already been closed." }
+        check(!indexBuffer.isClosed) { "Index buffer has already been closed." }
+        require((firstIndex + indexCount) * indexType.bytes <= indexBuffer.size) { "Tried to draw $indexCount $indexType indices starting from $firstIndex but buffer is only ${indexBuffer.size} bytes in size." }
+
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ drawCall(pipeline) {
+            //#if MC >= 26.2
+            //$$ mc.setVertexBuffer(0, vertexBuffer.mc)
+            //#else
+            //$$ mc.setVertexBuffer(0, vertexBuffer.buffer.impl.mc)
+            //#endif
+        //$$     mc.setIndexBuffer(indexBuffer.impl.mc, when (indexType) {
+                //#if MC >= 26.2
+                //$$ URenderPass.IndexType.SHORT -> com.mojang.blaze3d.IndexType.SHORT
+                //$$ URenderPass.IndexType.INT -> com.mojang.blaze3d.IndexType.INT
+                //#else
+                //$$ URenderPass.IndexType.SHORT -> VertexFormat.IndexType.SHORT
+                //$$ URenderPass.IndexType.INT -> VertexFormat.IndexType.INT
+                //#endif
+        //$$     })
+            //#if MC >= 26.2
+            //$$ mc.drawIndexed(indexCount, instanceCount, firstIndex, vertexOffset, firstInstance)
+            //#elseif MC >= 1.21.6
+            //$$ mc.drawIndexed(vertexOffset, firstIndex, indexCount, instanceCount)
+            //#else
+            //$$ mc.drawIndexed(firstIndex, indexCount)
+            //#endif
+        //$$ }
+        //#else
+        GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, indexBuffer.impl.glId)
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, vertexBuffer.buffer.impl.glId)
+        drawCall(pipeline) {
+            GL11.glDrawElements(
+                pipeline.drawMode.actualGlMode,
+                indexCount,
+                indexType.glId,
+                firstIndex.toLong() * indexType.bytes,
+            )
+        }
+        GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0)
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0)
+        //#endif
+    }
+
+    private fun drawCall(pipeline: URenderPipeline, draw: () -> Unit) {
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ mc.setPipeline(pipeline.compiled() ?: return)
+        //#else
+        if (currPipeline != pipeline) {
+            currPipeline?.unbind()
+            pipeline.bind()
+            pipeline.glState.activate(currGlState, prevGlState, false)
+            currPipeline = pipeline
+        }
+        //#endif
+
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ mc.enableScissor(scissor.x, scissor.y, scissor.width, scissor.height)
+        //#else
+        if (currScissor != scissor) {
+            scissor.activate()
+            currScissor = scissor
+        }
+        //#endif
+
+        for ((name, textureViewAndSampler) in textures) {
+            val (textureView, sampler) = textureViewAndSampler
+            check(!textureView.isClosed) { "Texture view for `$name` is closed" }
+            //#if MC >= 1.21.5 && !STANDALONE
+            //#if MC >= 1.21.11
+            //$$ mc.bindTexture(name, textureView.impl.mc, sampler.impl.mc)
+            //#elseif MC >= 1.21.6
+            //$$ sampler.impl.configureTexture(textureView.texture.impl.mc)
+            //$$ mc.bindSampler(name, textureView.impl.mc)
+            //#else
+            //$$ sampler.impl.configureTexture((textureView.texture.impl.mc as GlTexture).glId)
+            //$$ mc.bindSampler(name, textureView.texture.impl.mc)
+            //#endif
+            //#else
+            sampler.impl.configureTexture(textureView.texture.impl.glId)
+            pipeline.texture(name, textureView.texture.impl.glId)
+            //#endif
+        }
+
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ if (projectionUboDirty) {
+        //$$     mc.setUniform("Projection", allocUBO("Projection", projectionMatrix))
+        //$$     projectionUboDirty = false
+        //$$ }
+        //$$ if (dynamicTransformsUboDirty) {
+        //$$     mc.setUniform("DynamicTransforms", MemoryStack.stackPush().use { stack ->
+        //$$         val byteBuf = stack.malloc(DynamicUniforms.SIZE)
+        //$$         DynamicUniforms.UniformValue(
+        //$$             modelViewMatrix.let { org.joml.Matrix4f(
+        //$$                 it[ 0], it[ 1], it[ 2], it[ 3],
+        //$$                 it[ 4], it[ 5], it[ 6], it[ 7],
+        //$$                 it[ 8], it[ 9], it[10], it[11],
+        //$$                 it[12], it[13], it[14], it[15],
+        //$$             ) },
+        //$$             org.joml.Vector4f(1f, 1f, 1f, 1f),
+        //$$             org.joml.Vector3f(),
+        //$$             org.joml.Matrix4f(),
+                    //#if MC < 1.21.11
+                    //$$ 1f,
+                    //#endif
+        //$$         ).write(byteBuf)
+        //$$         byteBuf.flip()
+        //$$         RenderSystem.getDevice().createBuffer({ "DynamicTransforms UBO" }, GpuBuffer.USAGE_UNIFORM, byteBuf)
+        //$$     }.also { tmpBuffers.add(it) })
+        //$$     dynamicTransformsUboDirty = false
+        //$$ }
+        //#elseif MC >= 1.21.5 && !STANDALONE
+        //$$ mc.setUniform("ProjMat", *projectionMatrix)
+        //$$ mc.setUniform("ModelViewMat", *modelViewMatrix)
+        //$$ mc.setUniform("ColorModulator", 1f, 1f, 1f, 1f)
+        //#elseif MC >= 1.17
+        //$$ pipeline.uniform("ProjMat", *projectionMatrix)
+        //$$ pipeline.uniform("ModelViewMat", *modelViewMatrix)
+        //$$ pipeline.uniform("ColorModulator", 1f, 1f, 1f, 1f)
+        //#else
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPushMatrix()
+        GL11.glLoadIdentity()
+        GL11.glMultMatrix(tmpFloatBuffer.apply { put(projectionMatrix); flip() })
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+        GL11.glPushMatrix()
+        GL11.glLoadIdentity()
+        GL11.glMultMatrix(tmpFloatBuffer.apply { put(modelViewMatrix); flip() })
+        //#if MC >= 1.16
+        //$$ @Suppress("DEPRECATION")
+        //#endif
+        GlStateManager.color(1f, 1f, 1f, 1f)
+        //#endif
+
+        for ((name, value) in uniforms) {
+            when (value) {
+                //#if MC >= 1.21.6 && !STANDALONE
+                //$$ is FloatArray -> mc.setUniform(name, allocUBO(name, value).also { uniforms[name] = it })
+                //$$ is IntArray -> mc.setUniform(name, allocUBO(name, value).also { uniforms[name] = it })
+                //$$ is GpuBuffer -> mc.setUniform(name, value)
+                //$$ is GpuBufferSlice -> mc.setUniform(name, value)
+                //#elseif MC >= 1.21.5 && !STANDALONE
+                //$$ is FloatArray -> mc.setUniform(name, *value)
+                //$$ is IntArray -> mc.setUniform(name, *value)
+                //#else
+                is FloatArray -> pipeline.uniform(name, *value)
+                is IntArray -> pipeline.uniform(name, *value)
+                //#endif
+                else -> throw ClassCastException("Unexpected value of type ${value.javaClass}")
+            }
+        }
+
+        //#if MC == 1.21.5
+        //$$ // MC 1.21.5 implicitly applies global default uniforms (even overwriting manually specified ones).
+        //$$ // To prevent that, we set all uniform fields of `ShaderProgram` to `null`, so that `initializeUniform`
+        //$$ // effectively no-ops.
+        //$$ val compiledPipeline = RenderSystem.getDevice().precompilePipeline(pipeline.mcRenderPipeline)
+        //$$ val program = (compiledPipeline as net.minecraft.client.gl.CompiledShaderPipeline).program
+        //$$ val orgUniformFields = UniformFields()
+        //$$ orgUniformFields.copyFrom(program)
+        //$$ UniformFields().copyTo(program)
+        //#endif
+
+        //#if MC >= 1.21.5 && !STANDALONE
+        //$$ draw()
+        //#else
+        bind(pipeline.format)
+        //#if MC >= 1.17 && !STANDALONE
+        //$$ val shader = RenderSystem.getShader()!!
+        //$$ for (i in 0 until 8) {
+        //$$     shader.addSampler("Sampler$i", RenderSystem.getShaderTexture(i))
+        //$$ }
+        //$$ shader.bind()
+        //#endif
+        draw()
+        //#if MC >= 1.17 && !STANDALONE
+        //$$ shader.unbind()
+        //#endif
+        unbind(pipeline.format)
+        //#endif
+
+        //#if MC == 1.21.5
+        //$$ orgUniformFields.copyTo(program)
+        //#endif
+
+        //#if MC >= 1.17
+        //#else
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPopMatrix()
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+        GL11.glPopMatrix()
+        //#endif
+    }
+
+    //#if MC < 1.21.5 || STANDALONE
+    private fun bind(vertexFormat: VertexFormat) {
+        //#if MC >= 1.17
+        //$$ var index = 0
+        //#endif
+        //#if STANDALONE
+        //$$ val stride = vertexFormat.stride * 4
+        //$$ var nextOffset = 0L
+        //$$ for (part in vertexFormat.parts) {
+        //$$     val size = part.size
+        //$$     val type = GL11.GL_FLOAT
+        //$$     val normalized = false
+        //$$     val offset = nextOffset
+        //$$     nextOffset += part.size * 4
+        //#else
+        val stride = vertexFormat.nextOffset
+        var nextOffset = 0L
+        for (element in vertexFormat.elements) {
+            val size = element.size / element.type.size
+            val type = element.type.glConstant
+            val normalized = when (element.usage) {
+                //#if MC < 1.21
+                VertexFormatElement.EnumUsage.PADDING -> continue
+                //#endif
+                VertexFormatElement.EnumUsage.NORMAL,
+                VertexFormatElement.EnumUsage.COLOR -> true
+                else -> false
+            }
+            val offset = nextOffset
+            nextOffset += element.size
+        //#endif
+            //#if MC >= 1.17
+            //$$ GL20.glEnableVertexAttribArray(index)
+            //#if STANDALONE
+            //$$ GL20.glVertexAttribPointer(index, size, type, normalized, stride, offset)
+            //#else
+            //$$ if (element.type == VertexFormatElement.Type.UV && type != GL11.GL_FLOAT) {
+            //$$     GL30.glVertexAttribIPointer(index, size, type, stride, offset)
+            //$$ } else {
+            //$$     GL20.glVertexAttribPointer(index, size, type, normalized, stride, offset)
+            //$$ }
+            //#endif
+            //$$ index++
+            //#else
+            when (element.usage) {
+                VertexFormatElement.EnumUsage.POSITION -> {
+                    GL11.glVertexPointer(size, type, stride, offset)
+                    GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY)
+                }
+                VertexFormatElement.EnumUsage.NORMAL -> {
+                    GL11.glNormalPointer(type, stride, offset)
+                    GL11.glEnableClientState(GL11.GL_NORMAL_ARRAY)
+                }
+                VertexFormatElement.EnumUsage.COLOR -> {
+                    GL11.glColorPointer(size, type, stride, offset)
+                    GL11.glEnableClientState(GL11.GL_COLOR_ARRAY)
+                }
+                VertexFormatElement.EnumUsage.UV -> {
+                    GL13.glClientActiveTexture(GL13.GL_TEXTURE0 + element.index)
+                    GL11.glTexCoordPointer(size, type, stride, offset)
+                    GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY)
+                    GL13.glClientActiveTexture(GL13.GL_TEXTURE0)
+                }
+                VertexFormatElement.EnumUsage.GENERIC -> {
+                    GL20.glEnableVertexAttribArray(element.index)
+                    GL20.glVertexAttribPointer(element.index, size, type, normalized, stride, offset)
+                }
+                else -> {}
+            }
+            //#endif
+        }
+    }
+
+    private fun unbind(vertexFormat: VertexFormat) {
+        //#if MC >= 1.17
+        //$$ var index = 0
+        //#endif
+        //#if STANDALONE
+        //$$ for (part in vertexFormat.parts) {
+        //#else
+        for (element in vertexFormat.elements) {
+            //#if MC < 1.21
+            if (element.usage == VertexFormatElement.EnumUsage.PADDING) continue
+            //#endif
+        //#endif
+            //#if MC >= 1.17
+            //$$ GL20.glDisableVertexAttribArray(index)
+            //$$ index++
+            //#else
+            when (element.usage) {
+                VertexFormatElement.EnumUsage.POSITION -> {
+                    GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY)
+                }
+                VertexFormatElement.EnumUsage.NORMAL -> {
+                    GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY)
+                }
+                VertexFormatElement.EnumUsage.COLOR -> {
+                    GL11.glDisableClientState(GL11.GL_COLOR_ARRAY)
+                    //#if MC >= 1.16
+                    //$$ @Suppress("DEPRECATION")
+                    //$$ com.mojang.blaze3d.platform.GlStateManager.clearCurrentColor()
+                    //#else
+                    GlStateManager.resetColor()
+                    //#endif
+                }
+                VertexFormatElement.EnumUsage.UV -> {
+                    GL13.glClientActiveTexture(GL13.GL_TEXTURE0 + element.index)
+                    GL11.glDisableClientState(GL11.GL_TEXTURE_COORD_ARRAY)
+                    GL13.glClientActiveTexture(GL13.GL_TEXTURE0)
+                }
+                VertexFormatElement.EnumUsage.GENERIC -> {
+                    GL20.glDisableVertexAttribArray(element.index)
+                }
+                else -> {}
+            }
+            //#endif
+        }
+    }
+    //#endif
+
+    private val URenderPass.IndexType.glId: Int
+        get() = when (this) {
+            URenderPass.IndexType.SHORT -> GL11.GL_UNSIGNED_SHORT
+            URenderPass.IndexType.INT -> GL11.GL_UNSIGNED_INT
+        }
+
+    private val URenderPass.IndexType.bytes: Int
+        get() = when (this) {
+            URenderPass.IndexType.SHORT -> 2
+            URenderPass.IndexType.INT -> 4
+        }
+
+    @Suppress("DEPRECATION")
+    private val UGraphics.DrawMode.actualGlMode: Int
+        get() = when (this) {
+            UGraphics.DrawMode.LINES,
+            UGraphics.DrawMode.LINE_STRIP -> throw UnsupportedOperationException("Behavior of lines is inconsistent across versions")
+            UGraphics.DrawMode.TRIANGLES -> GL11.GL_TRIANGLES
+            UGraphics.DrawMode.TRIANGLE_STRIP -> GL11.GL_TRIANGLE_STRIP
+            UGraphics.DrawMode.TRIANGLE_FAN -> GL11.GL_TRIANGLE_FAN
+            UGraphics.DrawMode.QUADS -> GL11.GL_TRIANGLES
+        }
+
+    companion object {
+        private val framebuffer by lazy { glGenFramebuffers() }
+
+        private val vao by lazy { GL30.glGenVertexArrays() }
+
+        //#if MC < 1.17
+        // Note: LWJGL2 requires a buffer of 16 elements, even if the property we query only has 4
+        private val tmpFloatBuffer = ByteBuffer.allocateDirect(16 * Float.SIZE_BYTES).order(ByteOrder.nativeOrder()).asFloatBuffer()
+        //#endif
+
+        private val IDENTITY_MAT4 = FloatArray(16).also {
+            it[0] = 1f
+            it[5] = 1f
+            it[10] = 1f
+            it[15] = 1f
+        }
+
+        private var active = false
+    }
+}
+
+//#if MC == 1.21.5
+//$$ private class UniformFields(
+//$$     var modelViewMat: GlUniform? = null,
+//$$     var projectionMat: GlUniform? = null,
+//$$     var textureMat: GlUniform? = null,
+//$$     var screenSize: GlUniform? = null,
+//$$     var colorModulator: GlUniform? = null,
+//$$     var light0Direction: GlUniform? = null,
+//$$     var light1Direction: GlUniform? = null,
+//$$     var glintAlpha: GlUniform? = null,
+//$$     var fogStart: GlUniform? = null,
+//$$     var fogEnd: GlUniform? = null,
+//$$     var fogColor: GlUniform? = null,
+//$$     var fogShape: GlUniform? = null,
+//$$     var lineWidth: GlUniform? = null,
+//$$     var gameTime: GlUniform? = null,
+//$$     var modelOffset: GlUniform? = null,
+//$$ ) {
+//$$     fun copyFrom(program: ShaderProgram) {
+//$$         modelViewMat = program.modelViewMat
+//$$         projectionMat = program.projectionMat
+//$$         textureMat = program.textureMat
+//$$         screenSize = program.screenSize
+//$$         colorModulator = program.colorModulator
+//$$         light0Direction = program.light0Direction
+//$$         light1Direction = program.light1Direction
+//$$         glintAlpha = program.glintAlpha
+//$$         fogStart = program.fogStart
+//$$         fogEnd = program.fogEnd
+//$$         fogColor = program.fogColor
+//$$         fogShape = program.fogShape
+//$$         lineWidth = program.lineWidth
+//$$         gameTime = program.gameTime
+//$$         modelOffset = program.modelOffset
+//$$     }
+//$$     fun copyTo(program: ShaderProgram) {
+//$$         program.modelViewMat = modelViewMat
+//$$         program.projectionMat = projectionMat
+//$$         program.textureMat = textureMat
+//$$         program.screenSize = screenSize
+//$$         program.colorModulator = colorModulator
+//$$         program.light0Direction = light0Direction
+//$$         program.light1Direction = light1Direction
+//$$         program.glintAlpha = glintAlpha
+//$$         program.fogStart = fogStart
+//$$         program.fogEnd = fogEnd
+//$$         program.fogColor = fogColor
+//$$         program.fogShape = fogShape
+//$$         program.lineWidth = lineWidth
+//$$         program.gameTime = gameTime
+//$$         program.modelOffset = modelOffset
+//$$     }
+//$$ }
+//#endif

--- a/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
@@ -97,19 +97,29 @@ class URenderPipeline private constructor(
     //#if MC>=12105 && !STANDALONE
     //$$ private var shaderSourceGetter: ShaderSourceGetter?,
     //$$ internal val mcRenderPipeline: RenderPipeline,
+    //#if MC < 26.1
+    //$$ private val actualDepthTest: DepthTest?, // may be null for `wrap`ped pipeline
+    //#endif
     //#else
     private val shader: ShaderSupplier?,
     internal val glState: ManagedGlState,
     //#endif
 ) {
     //#if MC>=12105 && !STANDALONE
-    //$$ internal fun draw(renderPass: RenderPass, builtBuffer: BuiltBuffer) {
+    //$$ internal fun compiled(): RenderPipeline? {
+    //$$     val shaderSourceGetter = shaderSourceGetter
     //$$     if (shaderSourceGetter != null) {
     //$$         // Supply our shader sources to the render backend, need to do this each draw (it'll no-op if it's already
     //$$         // cached) because resource reloads will clear it again.
     //$$         RenderSystem.getDevice().precompilePipeline(mcRenderPipeline, shaderSourceGetter)
     //$$     }
-    //$$     renderPass.setPipeline(mcRenderPipeline)
+    //$$     return mcRenderPipeline
+    //$$ }
+    //#endif
+
+    //#if MC>=12105 && !STANDALONE
+    //$$ internal fun draw(renderPass: RenderPass, builtBuffer: BuiltBuffer) {
+    //$$     renderPass.setPipeline(compiled() ?: return)
     //$$
         //#if MC >= 26.2
         //$$ renderPass.drawIndexed(builtBuffer.drawState().indexCount, 1, 0, 0, 0)
@@ -273,6 +283,21 @@ class URenderPipeline private constructor(
         }
     }
     //#endif
+
+    internal val wantsDepthTexture: Boolean
+        // Prior to 26.1, MC's `wantsDepthTexture` also checks `depthMask`, but that defaults to `true` so it's
+        // useless for inferring whether a pipeline wants a depth texture (only those that expect a depth texture but
+        // don't want to overwrite it would ever set it), so we'll ignore that flag in our check.
+        //#if MC >= 26.1 && !STANDALONE
+        //$$ get() = mcRenderPipeline.wantsDepthTexture()
+        //#elseif MC >= 1.21.5 && !STANDALONE
+        //$$ get() = mcRenderPipeline.depthTestFunction != DepthTestFunction.NO_DEPTH_TEST
+        //$$         || (actualDepthTest != null && actualDepthTest != DepthTest.Disabled)
+        //$$         || mcRenderPipeline.depthBiasConstant != 0f
+        //$$         || mcRenderPipeline.depthBiasScaleFactor != 0f
+        //#else
+        get() = glState.depthTest || glState.polygonOffset
+        //#endif
 
     override fun toString(): String {
         return id.toString()
@@ -628,6 +653,9 @@ class URenderPipeline private constructor(
             //$$     format,
             //$$     shaderSourceGetter,
             //$$     mcRenderPipeline,
+                //#if MC < 26.1
+                //$$ depthTest,
+                //#endif
             //$$ )
             //#else
             return URenderPipeline(
@@ -708,7 +736,11 @@ class URenderPipeline private constructor(
             //#if MC >= 26.2
             //$$ URenderPipeline(mc.location, DrawMode.fromMc(mc.primitiveTopology), null, mc.vertexFormatBindings[0]!!, null, mc)
             //#else
-            //$$ URenderPipeline(mc.location, DrawMode.fromMc(mc.vertexFormatMode), null, mc.vertexFormat, null, mc)
+            //$$ URenderPipeline(mc.location, DrawMode.fromMc(mc.vertexFormatMode), null, mc.vertexFormat, null, mc,
+                //#if MC < 26.1
+                //$$ null,
+                //#endif
+            //$$ )
             //#endif
         //#endif
         //#if MC >= 26.2

--- a/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
@@ -12,6 +12,7 @@ import org.lwjgl.opengl.GL11
 //$$ import gg.essential.universal.standalone.render.DefaultShader
 //$$ import gg.essential.universal.standalone.render.VertexFormat
 //$$ import gg.essential.universal.vertex.UBuiltBufferInternal
+//$$ import org.lwjgl.opengl.GL20C
 //$$ typealias ResourceLocation = String
 //#else
 import net.minecraft.client.renderer.vertex.VertexFormat
@@ -121,7 +122,7 @@ class URenderPipeline private constructor(
     //#else
     internal fun draw(builtBuffer: UBuiltBufferInternal) {
         //#if STANDALONE
-        //$$ UGraphics.RENDERER.draw(builtBuffer.mc, drawMode, if (shader == null) DefaultShader.get(format.parts) else null)
+        //$$ UGraphics.RENDERER.draw(builtBuffer.mc, drawMode)
         //#else
         val mcBuiltBuffer = builtBuffer.mc
         //#if MC>=11900
@@ -184,18 +185,10 @@ class URenderPipeline private constructor(
 
     internal fun uniform(name: String, vararg values: Float) {
         when (shader) {
-            is ShaderSupplier.LegacySource -> {
-                val shader = shader.shader
-                when (values.size) {
-                    1 -> shader.getFloatUniformOrNull(name)?.setValue(values[0])
-                    2 -> shader.getFloat2UniformOrNull(name)?.setValue(values[0], values[1])
-                    3 -> shader.getFloat3UniformOrNull(name)?.setValue(values[0], values[1], values[2])
-                    4 -> shader.getFloat4UniformOrNull(name)?.setValue(values[0], values[1], values[2], values[3])
-                    9, 16 -> shader.getFloatMatrixUniformOrNull(name)?.setValue(values)
-                    else -> throw UnsupportedOperationException()
-                }
-            }
-            //#if MC>=11700 && !STANDALONE
+            is ShaderSupplier.LegacySource -> uniform(shader.shader, name, values)
+            //#if STANDALONE
+            //$$ is ShaderSupplier.Default -> uniform(shader.shader.shader, name, values)
+            //#elseif MC>=11700
             //$$ is ShaderSupplier.Mc -> {
             //$$     val shader = shader.shader.get()
             //$$     shader.getUniform(name)?.set(values)
@@ -208,14 +201,10 @@ class URenderPipeline private constructor(
 
     internal fun uniform(name: String, vararg values: Int) {
         when (shader) {
-            is ShaderSupplier.LegacySource -> {
-                val shader = shader.shader
-                when (values.size) {
-                    1 -> shader.getIntUniformOrNull(name)?.setValue(values[0])
-                    else -> throw UnsupportedOperationException()
-                }
-            }
-            //#if MC>=11700 && !STANDALONE
+            is ShaderSupplier.LegacySource -> uniform(shader.shader, name, values)
+            //#if STANDALONE
+            //$$ is ShaderSupplier.Default -> uniform(shader.shader.shader, name, values)
+            //#elseif MC>=11700
             //$$ is ShaderSupplier.Mc -> {
             //$$     val shader = shader.shader.get()
             //$$     shader.getUniform(name)?.set(values[0])
@@ -223,6 +212,24 @@ class URenderPipeline private constructor(
             //$$ }
             //#endif
             null -> throw IllegalStateException()
+        }
+    }
+
+    private fun uniform(shader: UShader, name: String, values: FloatArray) {
+        when (values.size) {
+            1 -> shader.getFloatUniformOrNull(name)?.setValue(values[0])
+            2 -> shader.getFloat2UniformOrNull(name)?.setValue(values[0], values[1])
+            3 -> shader.getFloat3UniformOrNull(name)?.setValue(values[0], values[1], values[2])
+            4 -> shader.getFloat4UniformOrNull(name)?.setValue(values[0], values[1], values[2], values[3])
+            9, 16 -> shader.getFloatMatrixUniformOrNull(name)?.setValue(values)
+            else -> throw UnsupportedOperationException()
+        }
+    }
+
+    private fun uniform(shader: UShader, name: String, values: IntArray) {
+        when (values.size) {
+            1 -> shader.getIntUniformOrNull(name)?.setValue(values[0])
+            else -> throw UnsupportedOperationException()
         }
     }
 
@@ -237,6 +244,9 @@ class URenderPipeline private constructor(
             //$$     RenderSystem.setShaderTexture(index, glId)
             //$$     return
             //$$ }
+            //#endif
+            //#if STANDALONE
+            //$$ is ShaderSupplier.Default,
             //#endif
             null -> {
                 val index = name.removePrefix("Sampler").toIntOrNull() ?: return
@@ -255,6 +265,9 @@ class URenderPipeline private constructor(
             //$$     RenderSystem.setShaderTexture(index, glId)
             //$$     return
             //$$ }
+            //#endif
+            //#if STANDALONE
+            //$$ is ShaderSupplier.Default,
             //#endif
             null -> UGraphics.Globals.bindTexture(index, glId)
         }
@@ -333,6 +346,19 @@ class URenderPipeline private constructor(
             }
             //#endif
         }
+
+        //#if STANDALONE
+        //$$ class Default(val shader: DefaultShader) : ShaderSupplier {
+        //$$     override fun bind(blendState: BlendState) {
+        //$$         shader.uSampler?.setValue(GL20C.glGetInteger(GL20C.GL_TEXTURE_BINDING_2D))
+        //$$         (shader.shader as GlShader).bind(skipBlendState = true)
+        //$$     }
+        //$$
+        //$$     override fun unbind() {
+        //$$         (shader.shader as GlShader).unbind(skipBlendState = true)
+        //$$     }
+        //$$ }
+        //#endif
 
         //#if MC>=11700 && !STANDALONE
         //#if MC>=12105

--- a/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
@@ -238,7 +238,10 @@ class URenderPipeline private constructor(
             //$$     return
             //$$ }
             //#endif
-            null -> throw IllegalStateException()
+            null -> {
+                val index = name.removePrefix("Sampler").toIntOrNull() ?: return
+                UGraphics.Globals.bindTexture(index, glId)
+            }
         }
     }
 

--- a/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
@@ -90,10 +90,9 @@ import net.minecraft.client.renderer.vertex.VertexFormatElement
 
 class URenderPipeline private constructor(
     private val id: ResourceLocation,
+    val drawMode: DrawMode,
+    val commonVertexFormat: CommonVertexFormats?,
     internal val format: VertexFormat,
-    //#if STANDALONE
-    //$$ private val drawMode: DrawMode,
-    //#endif
     //#if MC>=12105 && !STANDALONE
     //$$ private var shaderSourceGetter: ShaderSourceGetter?,
     //$$ internal val mcRenderPipeline: RenderPipeline,
@@ -410,6 +409,7 @@ class URenderPipeline private constructor(
     private class BuilderImpl(
         private val id: ResourceLocation,
         private val drawMode: DrawMode,
+        private val commonVertexFormat: CommonVertexFormats?,
         private val format: VertexFormat,
         //#if MC>=12105 && !STANDALONE
         //$$ private val shader: ShaderSupplier,
@@ -594,6 +594,8 @@ class URenderPipeline private constructor(
             //$$
             //$$ return URenderPipeline(
             //$$     id,
+            //$$     drawMode,
+            //$$     commonVertexFormat,
             //$$     format,
             //$$     shaderSourceGetter,
             //$$     mcRenderPipeline,
@@ -601,10 +603,9 @@ class URenderPipeline private constructor(
             //#else
             return URenderPipeline(
                 id,
+                drawMode,
+                commonVertexFormat,
                 format,
-                //#if STANDALONE
-                //$$ drawMode,
-                //#endif
                 shader,
                 ManagedGlState(
                     depthTest = depthTest != DepthTest.Disabled,
@@ -676,29 +677,29 @@ class URenderPipeline private constructor(
         //$$ @JvmStatic
         //$$ fun wrap(mc: RenderPipeline): URenderPipeline =
             //#if MC >= 26.2
-            //$$ URenderPipeline(mc.location, mc.vertexFormatBindings[0]!!, null, mc)
+            //$$ URenderPipeline(mc.location, DrawMode.fromMc(mc.primitiveTopology), null, mc.vertexFormatBindings[0]!!, null, mc)
             //#else
-            //$$ URenderPipeline(mc.location, mc.vertexFormat, null, mc)
+            //$$ URenderPipeline(mc.location, DrawMode.fromMc(mc.vertexFormatMode), null, mc.vertexFormat, null, mc)
             //#endif
         //#endif
         //#if MC >= 26.2
         //$$ fun builder(id: Identifier, drawMode: DrawMode, format: VertexFormat, vert: Identifier, frag: Identifier, bindGroupLayouts: List<BindGroupLayout>): Builder {
-        //$$     return BuilderImpl(id, drawMode, format, ShaderSupplier.Mc(vert, frag, bindGroupLayouts))
+        //$$     return BuilderImpl(id, drawMode, null, format, ShaderSupplier.Mc(vert, frag, bindGroupLayouts))
         //$$ }
         //#elseif MC >= 1.21.5
         //$$ fun builder(id: Identifier, drawMode: DrawMode, format: VertexFormat, vert: Identifier, frag: Identifier, samplers: List<String>, uniforms: Map<String, UniformType>): Builder {
-        //$$     return BuilderImpl(id, drawMode, format, ShaderSupplier.Mc(vert, frag, samplers, uniforms))
+        //$$     return BuilderImpl(id, drawMode, null, format, ShaderSupplier.Mc(vert, frag, samplers, uniforms))
         //$$ }
         //#else
         //#if MC>=11700
         //$$ fun builder(id: Identifier, drawMode: DrawMode, format: VertexFormat, shader: Supplier<Shader>?): Builder {
-        //$$     return BuilderImpl(id, drawMode, format, shader?.let { ShaderSupplier.Mc(it) })
+        //$$     return BuilderImpl(id, drawMode, null, format, shader?.let { ShaderSupplier.Mc(it) })
         //$$ }
         //#endif
         //#if MC>=12102
         //$$ fun builder(id: Identifier, drawMode: DrawMode, format: VertexFormat, shader: ShaderProgramKey): Builder {
         //$$     val shaderSupplier = Supplier { MinecraftClient.getInstance().shaderLoader.getProgramToLoad(shader) }
-        //$$     return BuilderImpl(id, drawMode, format, ShaderSupplier.Mc(shaderSupplier))
+        //$$     return BuilderImpl(id, drawMode, null, format, ShaderSupplier.Mc(shaderSupplier))
         //$$ }
         //#endif
         //#endif
@@ -706,7 +707,7 @@ class URenderPipeline private constructor(
 
         fun builderWithDefaultShader(id: String, drawMode: DrawMode, format: CommonVertexFormats): Builder {
             //#if STANDALONE
-            //$$ return BuilderImpl(id, drawMode, format.mc, null)
+            //$$ return BuilderImpl(id, drawMode, format, format.mc, ShaderSupplier.Default(DefaultShader.get(format.mc.parts)))
             //#else
             //#if MC>=12100
             //$$ val mcId = Identifier.of(id)
@@ -728,7 +729,7 @@ class URenderPipeline private constructor(
             //$$     if (format.mc.contains(DefaultVertexFormat.UV1_SEMANTIC_NAME)) add(BindGroupLayouts.SAMPLER1)
             //$$     if (format.mc.contains(DefaultVertexFormat.UV2_SEMANTIC_NAME)) add(BindGroupLayouts.SAMPLER2)
             //$$ }
-            //$$ return builder(mcId, drawMode, format.mc, shaderId, shaderId, bindGroupLayouts)
+            //$$ return BuilderImpl(mcId, drawMode, format, format.mc, ShaderSupplier.Mc(shaderId, shaderId, bindGroupLayouts))
             //#else
             //$$ val samplers = List(format.mc.elements.count {
                 //#if MC >= 26.1
@@ -747,22 +748,26 @@ class URenderPipeline private constructor(
                 //$$ "ColorModulator" to UniformType.VEC4,
                 //#endif
             //$$ )
-            //$$ return builder(mcId, drawMode, format.mc, shaderId, shaderId, samplers, uniforms)
+            //$$ return BuilderImpl(mcId, drawMode, format, format.mc, ShaderSupplier.Mc(shaderId, shaderId, samplers, uniforms))
             //#endif
             //#else
-            //$$ return builder(mcId, drawMode, format.mc, shader)
+            //$$ return BuilderImpl(mcId, drawMode, format, format.mc, ShaderSupplier.Mc(shader))
             //#endif
             //#else
-            return BuilderImpl(mcId, drawMode, format.mc, null)
+            return BuilderImpl(mcId, drawMode, format, format.mc, null)
             //#endif
             //#endif
         }
 
         fun builderWithLegacyShader(id: String, drawMode: DrawMode, format: CommonVertexFormats, vertSource: String, fragSource: String): Builder {
-            return builderWithLegacyShader(id, drawMode, format.mc, vertSource, fragSource)
+            return builderWithLegacyShader(id, drawMode, format, format.mc, vertSource, fragSource)
         }
 
         fun builderWithLegacyShader(id: String, drawMode: DrawMode, format: VertexFormat, vertSource: String, fragSource: String): Builder {
+            return builderWithLegacyShader(id, drawMode, null, format, vertSource, fragSource)
+        }
+
+        private fun builderWithLegacyShader(id: String, drawMode: DrawMode, commonVertexFormat: CommonVertexFormats?, format: VertexFormat, vertSource: String, fragSource: String): Builder {
             //#if STANDALONE
             //$$ val mcId = id
             //#elseif MC>=12100
@@ -770,7 +775,7 @@ class URenderPipeline private constructor(
             //#else
             val mcId = ResourceLocation(id)
             //#endif
-            return BuilderImpl(mcId, drawMode, format, ShaderSupplier.LegacySource(format, vertSource, fragSource))
+            return BuilderImpl(mcId, drawMode, commonVertexFormat, format, ShaderSupplier.LegacySource(format, vertSource, fragSource))
         }
     }
 }

--- a/src/main/kotlin/gg/essential/universal/render/ViewportState.kt
+++ b/src/main/kotlin/gg/essential/universal/render/ViewportState.kt
@@ -1,0 +1,31 @@
+package gg.essential.universal.render
+
+import org.lwjgl.opengl.GL11
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal data class ViewportState(val x: Int, val y: Int, val width: Int, val height: Int) {
+    fun activate() {
+        GL11.glViewport(x, y, width, height)
+    }
+
+    companion object {
+        // Note: LWJGL2 requires a buffer of 16 elements, even if the property we query only has 4
+        private val tmpIntBuffer = ByteBuffer.allocateDirect(16 * Int.SIZE_BYTES).order(ByteOrder.nativeOrder()).asIntBuffer()
+
+        fun active(): ViewportState {
+            val viewport = tmpIntBuffer
+                //#if MC>=11600
+                //$$ .also { GL11.glGetIntegerv(GL11.GL_VIEWPORT, it) }
+                //#else
+                .also { GL11.glGetInteger(GL11.GL_VIEWPORT, it) }
+                //#endif
+            return ViewportState(
+                x = viewport[0],
+                y = viewport[1],
+                width = viewport[2],
+                height = viewport[3],
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/render/font/UFontRenderer.kt
+++ b/src/main/kotlin/gg/essential/universal/render/font/UFontRenderer.kt
@@ -1,0 +1,511 @@
+package gg.essential.universal.render.font
+
+import gg.essential.universal.ChatColor
+import gg.essential.universal.UMatrixStack
+import gg.essential.universal.UMinecraft
+import gg.essential.universal.render.ScissorState
+import gg.essential.universal.render.UGpuDeviceImpl
+import gg.essential.universal.render.UGpuTexture
+import gg.essential.universal.render.UGpuTextureView
+import gg.essential.universal.render.ViewportState
+import org.lwjgl.opengl.GL11
+
+//#if STANDALONE
+//$$ import gg.essential.universal.UGraphics
+//$$ import gg.essential.universal.UResolution
+//$$ import gg.essential.universal.standalone.nanovg.NvgFont
+//$$ import java.awt.Color
+//#else
+import net.minecraft.client.gui.FontRenderer
+
+//#if MC >= 1.21.9
+//$$ import net.minecraft.client.font.TextDrawable
+//#elseif MC >= 1.21.6
+//$$ import net.minecraft.client.font.BakedGlyph
+//#endif
+
+//#if MC >= 1.21.6
+//$$ import com.mojang.blaze3d.pipeline.RenderPipeline
+//$$ import com.mojang.blaze3d.textures.GpuTextureView
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//$$ import com.mojang.blaze3d.vertex.VertexFormat
+//$$ import gg.essential.universal.render.UGpuBuffer
+//$$ import gg.essential.universal.render.UGpuSampler
+//$$ import gg.essential.universal.render.URenderPass
+//$$ import gg.essential.universal.render.URenderPassDescriptor
+//$$ import gg.essential.universal.render.URenderPassImpl
+//$$ import gg.essential.universal.render.URenderPipeline
+//$$ import net.minecraft.client.render.BufferBuilder
+//$$ import net.minecraft.client.render.fog.FogRenderer
+//$$ import net.minecraft.client.util.BufferAllocator
+//#endif
+
+//#if MC >= 1.21.5
+//$$ import gg.essential.universal.UGraphics
+//$$ import net.minecraft.client.MinecraftClient
+//#endif
+
+//#if MC >= 1.21.2
+//$$ import com.mojang.blaze3d.systems.ProjectionType
+//#elseif MC >= 1.20
+//$$ import com.mojang.blaze3d.systems.VertexSorter
+//#endif
+
+//#if MC >= 1.17 && MC < 1.21.6
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//#endif
+
+//#if MC >= 1.16 && MC < 1.21
+//$$ import net.minecraft.client.renderer.IRenderTypeBuffer
+//$$ import net.minecraft.client.renderer.Tessellator
+//#endif
+//#endif
+
+class UFontRenderer(
+    //#if STANDALONE
+    //$$ val mc: NvgFont,
+    //#else
+    val mc: FontRenderer,
+    //#endif
+) : AutoCloseable {
+    constructor() : this(
+        //#if STANDALONE
+        //$$ UGraphics.MC_FONT,
+        //#else
+        UMinecraft.getFontRenderer(),
+        //#endif
+    )
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ private val allocators = mutableListOf<BufferAllocator>()
+    //$$ private val fogRenderer: FogRenderer
+    //$$ init {
+    //$$     // The constructor of FogRenderer overwrites the global shader fog buffer with its own. This might already
+    //$$     // be undesireable by itself, but it gets worse: if no one replaces it by the time we `close`, the buffer
+    //$$     // is then invalidated, and OpenGL will end up reading random memory.
+    //$$     val prevFogUbo = RenderSystem.getShaderFog()
+    //$$     fogRenderer = FogRenderer()
+    //$$     RenderSystem.setShaderFog(prevFogUbo)
+    //$$ }
+    //#endif
+
+    class Text(
+        val x: Int,
+        val y: Int,
+        val scale: Float,
+        val text: String,
+        val color: Int,
+        val shadow: Boolean,
+        /**
+         * When non-null, uses this color for the entire shadow (provided [shadow] is `true`).
+         * Otherwise the color of the shadow is derived from the color of the text, and is therefore also affected by
+         * [formatting codes][ChatColor].
+         */
+        val shadowColor: Int?,
+    )
+
+    /**
+     * Renders the given [texts] to the [destination] texture.
+     *
+     * Note: This currently assumes that the texts do not overlap. The output for overlapping texts is undefined.
+     */
+    fun render(destination: UGpuTextureView, texts: List<Text>) {
+        require(destination.baseMipLevel == 0) { "baseMipLevel other than 0 is not yet supported" }
+
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ val drawerImpl = GlyphDrawerImpl()
+        //$$ for (text in texts) {
+        //$$     val scale = text.scale
+        //$$     val invScale = 1 / scale
+        //$$     drawerImpl.matrix.m00(scale).m11(scale)
+        //$$     val x = text.x * invScale
+        //$$     val y = text.y * invScale
+        //$$
+        //$$     drawerImpl.currBatch = 0
+        //$$
+        //$$     if (text.shadow && text.shadowColor != null) {
+        //$$         val shadowText = ChatColor.stripColorCodes(text.text)!!
+        //$$         mc.prepare(shadowText, x + 1f, y + 1f, text.shadowColor, false, 0).draw(drawerImpl)
+        //$$         mc.prepare(text.text, x, y, text.color, false, 0).draw(drawerImpl)
+        //$$     } else {
+        //$$         mc.prepare(text.text, x, y, text.color, text.shadow, 0).draw(drawerImpl)
+        //$$     }
+        //$$ }
+        //$$
+        //$$ val device = UGraphics.getDevice()
+        //$$ val adapter = UGraphics.getPlatformAdapter()
+        //$$ class DrawCall(
+        //$$     val pipeline: URenderPipeline,
+        //$$     val texture: UGpuTextureView,
+        //$$     val vertexBuffer: UGpuBuffer,
+        //$$     val indexBuffer: RenderSystem.ShapeIndexBuffer,
+        //$$     val indexCount: Int,
+        //$$ )
+        //$$ val drawCalls = drawerImpl.batches.mapNotNull { batch ->
+        //$$     batch.builder.endNullable()?.use { builtBuffer ->
+        //$$         DrawCall(
+        //$$             URenderPipeline.wrap(batch.pipeline),
+        //$$             adapter.textureView(batch.texture),
+        //$$             device.createBuffer(UGpuBuffer.Usage.VERTEX, builtBuffer.buffer),
+        //$$             RenderSystem.getSequentialBuffer(builtBuffer.drawParameters.mode()),
+        //$$             builtBuffer.drawParameters.indexCount(),
+        //$$         )
+        //$$     }
+        //$$ }
+        //$$ if (drawCalls.isEmpty()) return
+        //$$
+        //$$ val fogGpuBuffer = fogRenderer.getFogBuffer(FogRenderer.FogType.NONE)
+        //$$
+        //$$ val descriptor = URenderPassDescriptor { "Font rendering" }
+        //$$     .withColorAttachment(destination)
+        //$$ device.createRenderPass(descriptor).use { renderPass ->
+        //$$     val w = destination.texture.width
+        //$$     val h = destination.texture.height
+        //$$     renderPass.projectionMatrix(floatArrayOf(
+        //$$         2f/w, 0f,    0f,   0f,
+        //$$         0f,   -2f/h, 0f,   0f,
+        //$$         0f,   0f,    1f,   0f,
+        //$$         -1f,  1f,    0f,   1f,
+        //$$     ))
+        //$$     renderPass.uniform("Fog", UGraphics.getPlatformAdapter().bufferSlice(fogGpuBuffer))
+        //$$     val samplerNearest = UGpuSampler(
+        //$$         UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+        //$$         UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+        //$$         UGpuSampler.FilterMode.NEAREST,
+        //$$         UGpuSampler.FilterMode.NEAREST,
+        //$$         false,
+        //$$     )
+        //$$     renderPass.texture("Sampler2", adapter.textureView(drawerImpl.lightTexture), UGpuSampler(
+        //$$         UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+        //$$         UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+        //$$         UGpuSampler.FilterMode.LINEAR,
+        //$$         UGpuSampler.FilterMode.LINEAR,
+        //$$         false,
+        //$$     ))
+        //$$     for (drawCall in drawCalls) {
+        //$$         // MC's font renderer only starts using a depth-less pipeline with 1.21.9, so we'll bypass the
+        //$$         // check in `pipeline` on those versions.
+        //$$         // Because the check only becomes relevant with 26.2, that's when we'll switch to the checked call.
+                //#if MC >= 26.2
+                //$$ renderPass.pipeline(drawCall.pipeline)
+                //#else
+                //$$ (renderPass as URenderPassImpl).pipelineUnchecked(drawCall.pipeline)
+                //#endif
+        //$$         renderPass.vertexBuffer(0, drawCall.vertexBuffer.slice())
+        //$$         renderPass.indexBuffer(
+        //$$             adapter.buffer(drawCall.indexBuffer.getIndexBuffer(drawCall.indexCount)),
+        //$$             when (drawCall.indexBuffer.indexType) {
+                        //#if MC >= 26.2
+                        //$$ com.mojang.blaze3d.IndexType.SHORT -> URenderPass.IndexType.SHORT
+                        //$$ com.mojang.blaze3d.IndexType.INT -> URenderPass.IndexType.INT
+                        //#else
+                        //$$ VertexFormat.IndexType.SHORT -> URenderPass.IndexType.SHORT
+                        //$$ VertexFormat.IndexType.INT -> URenderPass.IndexType.INT
+                        //#endif
+        //$$                 null -> throw NullPointerException()
+        //$$             },
+        //$$         )
+        //$$         renderPass.texture("Sampler0", drawCall.texture, samplerNearest)
+        //$$         renderPass.drawIndexed(drawCall.indexCount)
+        //$$     }
+        //$$ }
+        //$$ drawCalls.forEach { it.vertexBuffer.close() }
+        //#else
+        val texture = destination.texture
+        withDrawFramebuffer(texture) {
+            val prevViewport = ViewportState.active()
+            val viewport = ViewportState(0, 0, texture.width, texture.height)
+            if (viewport != prevViewport) {
+                viewport.activate()
+            }
+            val prevScissor = ScissorState.active()
+            if (prevScissor.enabled) ScissorState.DISABLED.activate()
+
+            val projMat = UMatrixStack()
+            projMat.scale(1f, -1f, 1f)
+            projMat.translate(-1f, -1f, 0f)
+            projMat.scale(2f / texture.width, 2f / texture.height, 1f)
+
+            //#if STANDALONE
+            //$$ val prevWidth = UResolution.viewportWidth
+            //$$ val prevHeight = UResolution.viewportHeight
+            //$$ val prevScale = UMinecraft.guiScale
+            //$$ UResolution.viewportWidth = texture.width
+            //$$ UResolution.viewportHeight = texture.height
+            //$$ UMinecraft.guiScale = 1
+            //$$ UMatrixStack.GLOBAL_STACK.push()
+            //$$ UMatrixStack().replaceGlobalState()
+            //#elseif MC >= 1.17
+            //$$ val orgProjMat = RenderSystem.getProjectionMatrix()
+            //#if MC >= 1.21.2
+            //$$ val orgProjectionType = RenderSystem.getProjectionType()
+            //$$ RenderSystem.setProjectionMatrix(projMat.peek().model, ProjectionType.ORTHOGRAPHIC)
+            //#elseif MC >= 1.20
+            //$$ val orgVertexSorter = RenderSystem.getVertexSorting()
+            //$$ RenderSystem.setProjectionMatrix(projMat.peek().model, VertexSorter.BY_Z)
+            //#else
+            //$$ RenderSystem.setProjectionMatrix(projMat.peek().model)
+            //#endif
+            //#if MC >= 1.20.6
+            //$$ RenderSystem.getModelViewStack().pushMatrix()
+            //$$ RenderSystem.getModelViewStack().identity()
+            //#else
+            //$$ RenderSystem.getModelViewStack().push()
+            //$$ RenderSystem.getModelViewStack().loadIdentity()
+            //#endif
+            //#if MC < 1.21.2
+            //$$ RenderSystem.applyModelViewMatrix()
+            //#endif
+            //#else
+            GL11.glMatrixMode(GL11.GL_PROJECTION)
+            GL11.glPushMatrix()
+            projMat.replaceGlobalState()
+            GL11.glMatrixMode(GL11.GL_MODELVIEW)
+            GL11.glPushMatrix()
+            GL11.glLoadIdentity()
+            //#endif
+
+            //#if MC >= 1.16
+            //$$ val stack = UMatrixStack()
+            //#endif
+
+            //#if STANDALONE
+            //#elseif MC >= 1.21
+            //$$ val buffer = UMinecraft.getMinecraft().bufferBuilders.entityVertexConsumers
+            //#elseif MC >= 1.16
+            //$$ val buffer = IRenderTypeBuffer.getImpl(Tessellator.getInstance().buffer)
+            //#endif
+
+            var currScale = 1f
+            for (text in texts) {
+                val scale = text.scale
+                //#if STANDALONE
+                //$$ // scaling passed through to `drawString`
+                //$$ val x = text.x.toFloat()
+                //$$ val y = text.y.toFloat()
+                //#else
+                if (scale != currScale) {
+                    //#if MC >= 1.17
+                    //#if MC >= 1.20.6
+                    //$$ stack.peek().model.identity()
+                    //#else
+                    //$$ stack.peek().model.loadIdentity()
+                    //#endif
+                    //$$ stack.scale(scale, scale, scale)
+                    //#else
+                    GL11.glLoadIdentity()
+                    GL11.glScalef(scale, scale, scale)
+                    //#endif
+                    currScale = scale
+                }
+                val invScale = 1 / scale
+                val x = text.x * invScale
+                val y = text.y * invScale
+                //#endif
+
+                if (text.shadow && text.shadowColor != null) {
+                    val shadowText = ChatColor.stripColorCodes(text.text)!!
+                    //#if STANDALONE
+                    //$$ mc.drawString(UMatrixStack.UNIT, shadowText, Color(text.shadowColor), x + 1f, y + 1f, 10f, scale, false, null)
+                    //$$ mc.drawString(UMatrixStack.UNIT, text.text, Color(text.color), x, y, 10f, scale, false, null)
+                    //#elseif MC >= 1.16
+                    //$$ mc.renderString(shadowText, x + 1f, y + 1f, text.shadowColor, false, stack.peek().model, buffer, TEXT_LAYER_TYPE, 0, 15728880)
+                    //$$ mc.renderString(text.text, x, y, text.color, false, stack.peek().model, buffer, TEXT_LAYER_TYPE, 0, 15728880)
+                    //#elseif MC >= 1.15
+                    //$$ mc.drawString(shadowText, x + 1f, y + 1f, text.shadowColor)
+                    //$$ mc.drawString(text.text, x, y, text.color)
+                    //#else
+                    mc.drawString(shadowText, x + 1f, y + 1f, text.shadowColor, false)
+                    mc.drawString(text.text, x, y, text.color, false)
+                    //#endif
+                } else {
+                    //#if STANDALONE
+                    //$$ mc.drawString(UMatrixStack.UNIT, text.text, Color(text.color), x, y, 10f, scale, text.shadow, null)
+                    //#elseif MC >= 1.16
+                    //$$ mc.renderString(text.text, x, y, text.color, text.shadow, stack.peek().model, buffer, TEXT_LAYER_TYPE, 0, 15728880)
+                    //#elseif MC >= 1.15
+                    //$$ if (text.shadow) {
+                    //$$     mc.drawStringWithShadow(text.text, x, y, text.color)
+                    //$$ } else {
+                    //$$     mc.drawString(text.text, x, y, text.color)
+                    //$$ }
+                    //#else
+                    mc.drawString(text.text, x, y, text.color, text.shadow)
+                    //#endif
+                }
+            }
+
+            //#if STANDALONE
+            //#elseif MC >= 1.16
+            //$$ buffer.finish()
+            //#endif
+
+            //#if STANDALONE
+            //$$ UMatrixStack.GLOBAL_STACK.pop()
+            //$$ UResolution.viewportWidth = prevWidth
+            //$$ UResolution.viewportHeight = prevHeight
+            //$$ UMinecraft.guiScale = prevScale
+            //#elseif MC >= 1.17
+            //#if MC >= 1.20.6
+            //$$ RenderSystem.getModelViewStack().popMatrix()
+            //#else
+            //$$ RenderSystem.getModelViewStack().pop()
+            //#endif
+            //#if MC < 1.21.2
+            //$$ RenderSystem.applyModelViewMatrix()
+            //#endif
+            //#if MC >= 1.21.2
+            //$$ RenderSystem.setProjectionMatrix(orgProjMat, orgProjectionType)
+            //#elseif MC >= 1.20
+            //$$ RenderSystem.setProjectionMatrix(orgProjMat, orgVertexSorter)
+            //#else
+            //$$ RenderSystem.setProjectionMatrix(orgProjMat)
+            //#endif
+            //#else
+            GL11.glMatrixMode(GL11.GL_PROJECTION)
+            GL11.glPopMatrix()
+            GL11.glMatrixMode(GL11.GL_MODELVIEW)
+            GL11.glPopMatrix()
+            //#endif
+
+            if (prevScissor.enabled) prevScissor.activate()
+            if (viewport != prevViewport) {
+                prevViewport.activate()
+            }
+        }
+        //#endif
+    }
+
+    override fun close() {
+        //#if MC >= 1.21.6 && !STANDALONE
+        //$$ allocators.forEach { it.close() }
+        //$$ allocators.clear()
+        //$$ fogRenderer.close()
+        //#endif
+    }
+
+    //#if MC >= 1.21.6 && !STANDALONE
+    //$$ private class DrawBatch(
+    //$$     val pipeline: RenderPipeline,
+    //$$     val texture: GpuTextureView,
+    //$$     val builder: BufferBuilder,
+    //$$ )
+    //$$ private inner class GlyphDrawerImpl : TextRenderer.GlyphDrawer {
+        //#if MC >= 26.1
+        //$$ val lightTexture = Minecraft.getInstance().gameRenderer.lightmap()
+        //$$ // lightmap() may return either the uiLightmap, which is 1x1, or the regular lightmap (like pre-26.1)
+        //$$ // and the text shader uses texelFetch which ignores the wrapping mode, so we need to pass it 0/0 as the
+        //$$ // light coord or it will simply return 0 as the color.
+        //$$ // for the 0, see GlyphRenderState.buildVertices
+        //$$ // for the 0x00F0_00F0, see e.g. DrawableGizmoPrimitives.Group.renderTexts
+        //$$ val light = if (lightTexture.getWidth(0) == 1) 0 else 0x00F0_00F0
+        //#else
+        //$$ val lightTexture = MinecraftClient.getInstance().gameRenderer.lightmapTextureManager.glTextureView
+        //$$ val light = 0x00F0_00F0 // see GlyphGuiElementRenderState.setupVertices
+        //#endif
+    //$$
+    //$$     // Ideally we'd render everything in a single draw call. But when MC has seen enough glyphs that they don't
+    //$$     // fit on its single atlas any more, it starts a second atlas, at which point we'll need multiple draw
+    //$$     // calls with different textures.
+    //$$     // Within a single text we have to preserve the order in which MC supplies us the glyphs, otherwise we
+    //$$     // could end up rendering the background on the foreground, or strikethrough behind the letters, etc.
+    //$$     // Different texts are independent though, and so can share the same set of draw batches.
+    //$$     val batches = mutableListOf<DrawBatch>()
+    //$$     var currBatch = 0
+    //$$
+    //$$     val matrix = org.joml.Matrix4f()
+    //$$
+    //$$     private fun builder(pipeline: RenderPipeline, texture: GpuTextureView): BufferBuilder {
+    //$$         while (true) {
+    //$$             if (currBatch > batches.lastIndex) {
+    //$$                 if (currBatch > allocators.lastIndex) allocators.add(BufferAllocator(65536))
+    //$$                 val builder = BufferBuilder(
+    //$$                     allocators[currBatch],
+                        //#if MC >= 26.2
+                        //$$ pipeline.primitiveTopology,
+                        //$$ pipeline.getVertexFormatBinding(0)!!,
+                        //#else
+                        //$$ pipeline.vertexFormatMode,
+                        //$$ pipeline.vertexFormat,
+                        //#endif
+    //$$                 )
+    //$$                 batches.add(DrawBatch(pipeline, texture, builder))
+    //$$             }
+    //$$             val batch = batches[currBatch]
+    //$$             if (batch.pipeline == pipeline && batch.texture == texture) {
+    //$$                 return batch.builder
+    //$$             }
+    //$$             currBatch++
+    //$$         }
+    //$$     }
+    //$$
+    //#if MC >= 1.21.9
+    //$$     private fun draw(drawable: TextDrawable) =
+    //$$         drawable.render(matrix, builder(drawable.pipeline, drawable.textureView()), light, false)
+    //#if MC >= 1.21.11
+    //$$     override fun drawGlyph(glyph: TextDrawable.DrawnGlyphRect) = draw(glyph)
+    //#else
+    //$$     override fun drawGlyph(drawable: TextDrawable) = draw(drawable)
+    //#endif
+    //$$     override fun drawRectangle(drawable: TextDrawable) = draw(drawable)
+    //#else
+    //$$     override fun drawGlyph(drawnGlyph: BakedGlyph.DrawnGlyph) {
+    //$$         val bakedGlyph = drawnGlyph.glyph()
+    //$$         val texture = bakedGlyph.texture ?: return
+    //$$         bakedGlyph.draw(drawnGlyph, matrix, builder(bakedGlyph.pipeline, texture), light, false)
+    //$$     }
+    //$$     override fun drawRectangle(bakedGlyph: BakedGlyph, rectangle: BakedGlyph.Rectangle) {
+    //$$         val texture = bakedGlyph.texture ?: return
+    //$$         bakedGlyph.drawRectangle(rectangle, matrix, builder(bakedGlyph.pipeline, texture), light, false)
+    //$$     }
+    //#endif
+    //$$ }
+    //#else
+    private inline fun withDrawFramebuffer(color: UGpuTexture, block: () -> Unit) {
+        //#if MC == 1.21.5
+        //$$ val fb = MinecraftClient.getInstance().framebuffer
+        //$$ val orgColor = fb.colorAttachment
+        //$$ val orgDepth = fb.depthAttachment
+        //$$ fbAttachmentFieldSetters.first.invoke(fb, UGraphics.getPlatformAdapter().texture(color))
+        //$$ fbAttachmentFieldSetters.second.invoke(fb, null)
+        //$$ try {
+        //$$     return block()
+        //$$ } finally {
+        //$$     fbAttachmentFieldSetters.first.invoke(fb, orgColor)
+        //$$     fbAttachmentFieldSetters.second.invoke(fb, orgDepth)
+        //$$ }
+        //#else
+        UGpuDeviceImpl.withDrawFramebuffer(color, null, block)
+        //#endif
+    }
+    //#endif
+
+    //#if MC == 1.21.5
+    //$$ private val fbAttachmentFieldSetters by lazy {
+    //$$     val fb = MinecraftClient.getInstance().framebuffer
+    //$$     val lookup = java.lang.invoke.MethodHandles.lookup()
+    //$$     val cls = net.minecraft.client.gl.Framebuffer::class.java
+    //$$     val gpuTextureFields = cls.declaredFields.filter {
+    //$$         it.type == com.mojang.blaze3d.textures.GpuTexture::class.java
+    //$$     }
+    //$$     val colorField = lookup.unreflectSetter(gpuTextureFields.first {
+    //$$         it.isAccessible = true
+    //$$         it.get(fb) == fb.colorAttachment
+    //$$     })
+    //$$     val depthField = lookup.unreflectSetter(gpuTextureFields.first {
+    //$$         it.isAccessible = true
+    //$$         it.get(fb) == fb.depthAttachment
+    //$$     })
+    //$$     Pair(colorField, depthField)
+    //$$ }
+    //#endif
+
+    private companion object {
+        //#if MC >= 1.21.6
+        //#elseif MC >= 1.19.4
+        //$$ private val TEXT_LAYER_TYPE = TextRenderer.TextLayerType.NORMAL
+        //#elseif MC >= 1.16
+        //$$ private val TEXT_LAYER_TYPE = false
+        //#endif
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/vertex/UBuiltBuffer.kt
+++ b/src/main/kotlin/gg/essential/universal/vertex/UBuiltBuffer.kt
@@ -4,6 +4,7 @@ import gg.essential.universal.render.DrawCallBuilder
 import gg.essential.universal.render.URenderPassLegacyImpl
 import gg.essential.universal.render.URenderPipeline
 import org.jetbrains.annotations.ApiStatus.NonExtendable
+import java.nio.ByteBuffer
 
 //#if STANDALONE
 //#else
@@ -30,6 +31,13 @@ import net.minecraft.client.renderer.WorldRenderer as BuiltBuffer
  */
 @NonExtendable // will be cast to UBuiltBufferInternal
 interface UBuiltBuffer : AutoCloseable {
+    /**
+     * Returns the raw [ByteBuffer] data.
+     * This consumes the underlying [UBuiltBuffer], no method other than [close] may be called afterwards.
+     * The returned [ByteBuffer] is only guaranteed to be valid until [close] is called.
+     */
+    fun toByteBuffer(): ByteBuffer
+
     fun drawAndClose(pipeline: URenderPipeline, configure: DrawCallBuilder.() -> Unit = {}): Unit =
         use { draw(pipeline, configure) }
 

--- a/src/main/kotlin/gg/essential/universal/vertex/UBuiltBufferInternal.kt
+++ b/src/main/kotlin/gg/essential/universal/vertex/UBuiltBufferInternal.kt
@@ -1,5 +1,7 @@
 package gg.essential.universal.vertex
 
+import java.nio.ByteBuffer
+
 //#if STANDALONE
 //$$ import gg.essential.universal.standalone.render.BufferBuilder as BuiltBuffer
 //#elseif MC>=12100
@@ -13,4 +15,24 @@ import net.minecraft.client.renderer.WorldRenderer as BuiltBuffer
 internal interface UBuiltBufferInternal : UBuiltBuffer {
     val mc: BuiltBuffer
     fun closedExternally()
+
+    override fun toByteBuffer(): ByteBuffer {
+        //#if STANDALONE
+        //$$ return mc.byteBuffer
+        //#elseif MC >= 1.21
+        //$$ return mc.buffer
+        //#elseif MC >= 1.19
+        //$$ return mc.vertexBuffer
+        //#elseif MC >= 1.16
+        //$$ return mc.nextBuffer.second
+        //#else
+        return mc.byteBuffer
+        //#endif
+        //#if MC >= 1.20.4 && !STANDALONE
+        //$$     // Buffers used exclusively for sorting won't have any vertex data.
+        //$$     // Our API doesn't provide any way to construct such buffers, so we'll just throw when someone used `wrap`
+        //$$     // on such a buffer.
+        //$$     ?: throw IllegalStateException("Cannot get vertex data of index-only buffer")
+        //#endif
+    }
 }

--- a/standalone/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -1,5 +1,8 @@
 package gg.essential.universal
 
+import gg.essential.universal.render.UGpuTextureView
+import java.lang.AutoCloseable
+
 abstract class UScreen(
     val restoreCurrentGuiOnClose: Boolean = false,
     open var newGuiScale: Int = -1,
@@ -45,6 +48,18 @@ abstract class UScreen(
     open fun initScreen(width: Int, height: Int) {
     }
 
+    interface Renderer : AutoCloseable {
+        fun render(state: RenderState): UGpuTextureView
+    }
+
+    interface RenderState {
+        val background: Boolean
+    }
+
+    open fun uCreateRenderer(): Renderer? = null
+
+    open fun uExtractRenderState(mouseX: Int, mouseY: Int, partialTicks: Float): RenderState = throw NotImplementedError()
+
     open fun onDrawScreen(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
     }
 
@@ -88,5 +103,8 @@ abstract class UScreen(
             currentScreen = screen
             currentScreen?.initGui()
         }
+
+        val isRendererRequired: Boolean
+            get() = false
     }
 }

--- a/standalone/src/main/kotlin/gg/essential/universal/standalone/UCWindow.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/standalone/UCWindow.kt
@@ -1,5 +1,6 @@
 package gg.essential.universal.standalone
 
+import gg.essential.universal.UGraphics
 import gg.essential.universal.standalone.glfw.Glfw
 import gg.essential.universal.standalone.glfw.GlfwWindow
 import gg.essential.universal.UKeyboard
@@ -8,6 +9,11 @@ import gg.essential.universal.UMatrixStack
 import gg.essential.universal.UMouse
 import gg.essential.universal.UResolution
 import gg.essential.universal.UScreen
+import gg.essential.universal.render.UGpuSampler
+import gg.essential.universal.render.UGpuSampler.Companion.invoke
+import gg.essential.universal.render.URenderPipeline
+import gg.essential.universal.shader.BlendState
+import gg.essential.universal.vertex.UBufferBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -125,6 +131,8 @@ class UCWindow(val glfwWindow: GlfwWindow, val uiScope: CoroutineScope) {
     }
 
     suspend fun renderScreenUntilClosed() {
+        var prevScreen: UScreen? = null
+        var renderer: UScreen.Renderer? = null
         var nextTick = 0f
         renderLoop { _, deltaTime ->
             val screen = UScreen.currentScreen ?: return@renderLoop false
@@ -135,9 +143,48 @@ class UCWindow(val glfwWindow: GlfwWindow, val uiScope: CoroutineScope) {
                 screen.onTick()
             }
 
-            screen.onDrawScreen(UMatrixStack(), UMouse.Scaled.x.toInt(), UMouse.Scaled.y.toInt(), nextTick + 1 / 20f)
+            if (prevScreen != screen) {
+                prevScreen = screen
+                renderer?.close()
+                renderer = null
+            }
+            val renderer = renderer ?: screen.uCreateRenderer()?.also { renderer = it }
+            if (renderer != null) {
+                val renderState = screen.uExtractRenderState(UMouse.Scaled.x.toInt(), UMouse.Scaled.y.toInt(), nextTick + 1 / 20f)
+                val textureView = renderer.render(renderState)
+                val x1 = 0.0
+                val x2 = UResolution.scaledWidth.toDouble()
+                val y1 = 0.0
+                val y2 = UResolution.scaledHeight.toDouble()
+                val buffer = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE)
+                buffer.pos(UMatrixStack.UNIT, x1, y2, 0.0).tex(0.0, 0.0).endVertex()
+                buffer.pos(UMatrixStack.UNIT, x2, y2, 0.0).tex(1.0, 0.0).endVertex()
+                buffer.pos(UMatrixStack.UNIT, x2, y1, 0.0).tex(1.0, 1.0).endVertex()
+                buffer.pos(UMatrixStack.UNIT, x1, y1, 0.0).tex(0.0, 1.0).endVertex()
+                buffer.build()?.drawAndClose(PIPELINE_BLIT) {
+                    texture(0, textureView, SAMPLER_NEAREST)
+                }
+            } else {
+                screen.onDrawScreen(UMatrixStack(), UMouse.Scaled.x.toInt(), UMouse.Scaled.y.toInt(), nextTick + 1 / 20f)
+            }
 
             return@renderLoop true
         }
     }
 }
+
+private val PIPELINE_BLIT = URenderPipeline.builderWithDefaultShader(
+    "universalcraft:blit",
+    UGraphics.DrawMode.QUADS,
+    UGraphics.CommonVertexFormats.POSITION_TEXTURE,
+).apply {
+    blendState = BlendState.PREMULTIPLIED_ALPHA
+}.build()
+
+private val SAMPLER_NEAREST = UGpuSampler(
+    UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+    UGpuSampler.AddressMode.CLAMP_TO_EDGE,
+    UGpuSampler.FilterMode.NEAREST,
+    UGpuSampler.FilterMode.NEAREST,
+    false,
+)

--- a/standalone/src/main/kotlin/gg/essential/universal/standalone/render/BufferBuilder.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/standalone/render/BufferBuilder.kt
@@ -9,6 +9,9 @@ import gg.essential.universal.vertex.UBufferBuilder
 import gg.essential.universal.vertex.UBuiltBuffer
 import gg.essential.universal.vertex.UBuiltBufferInternal
 import gg.essential.universal.vertex.UVertexConsumer
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
 
 internal class BufferBuilder(
     val attributes: List<Part>,
@@ -17,7 +20,10 @@ internal class BufferBuilder(
     val stride: Int = attributes.sumOf { it.size }
 
     private var idx: Int = 0
-    internal var array: FloatArray = FloatArray(stride * 64)
+    internal var byteBuffer: ByteBuffer = ByteBuffer.allocateDirect(stride * 64 * 4).order(ByteOrder.nativeOrder())
+    internal var array = byteBuffer.asFloatBuffer()
+
+    private operator fun FloatBuffer.set(index: Int, value: Float) = put(index, value)
 
     /** How many vertices there are in this buffer */
     val count: Int
@@ -70,12 +76,17 @@ internal class BufferBuilder(
     }
 
     override fun endVertex() = apply {
-        if (idx > array.lastIndex) {
-            array = array.copyOf(array.size * 2)
+        if (idx >= array.remaining()) {
+            val clone = ByteBuffer.allocateDirect(byteBuffer.remaining() * 2).order(ByteOrder.nativeOrder())
+            clone.put(byteBuffer)
+            clone.position(0)
+            byteBuffer = clone
+            array = clone.asFloatBuffer()
         }
     }
 
     override fun build(): UBuiltBuffer? {
+        byteBuffer.limit(idx * 4)
         return this.takeIf { count > 0 }
     }
 

--- a/standalone/src/main/kotlin/gg/essential/universal/standalone/render/Gl2Renderer.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/standalone/render/Gl2Renderer.kt
@@ -10,7 +10,7 @@ internal class Gl2Renderer {
     private val vertexBuffer = GL20C.glGenBuffers()
     private val indexBuffer = GL20C.glGenBuffers()
 
-    fun draw(bufferBuilder: BufferBuilder, drawMode: UGraphics.DrawMode, shader: DefaultShader?) {
+    fun draw(bufferBuilder: BufferBuilder, drawMode: UGraphics.DrawMode) {
         if (GL.getCapabilities().OpenGL30) {
             GL30C.glBindVertexArray(vao)
         }
@@ -18,10 +18,6 @@ internal class Gl2Renderer {
         for (i in bufferBuilder.attributes.indices) {
             GL20C.glEnableVertexAttribArray(i)
         }
-
-        shader?.uSampler?.setValue(GL20C.glGetInteger(GL20C.GL_TEXTURE_BINDING_2D))
-
-        shader?.shader?.bind()
 
         GL20C.glBindBuffer(GL20C.GL_ARRAY_BUFFER, vertexBuffer)
         GL20C.glBufferData(GL20C.GL_ARRAY_BUFFER, bufferBuilder.array, GL20C.GL_STATIC_DRAW)
@@ -47,8 +43,6 @@ internal class Gl2Renderer {
             }
             else -> TODO("Support rendering $drawMode")
         }
-
-        shader?.shader?.unbind()
 
         for (i in bufferBuilder.attributes.indices) {
             GL20C.glDisableVertexAttribArray(i)

--- a/versions/1.16.2-1.12.2.txt
+++ b/versions/1.16.2-1.12.2.txt
@@ -29,3 +29,5 @@ com.mojang.blaze3d.systems.RenderSystem enableColorLogicOp() enableColorLogic()
 com.mojang.blaze3d.systems.RenderSystem logicOp() colorLogicOp()
 com.mojang.blaze3d.systems.RenderSystem polygonOffset() doPolygonOffset()
 net.minecraft.client.renderer.vertex.DefaultVertexFormats POSITION_TEX_LIGHTMAP_COLOR POSITION_TEX_LMAP_COLOR
+org.lwjgl.opengl.GL11 org.lwjgl.opengl.GL11
+org.lwjgl.opengl.GL11 glMultMatrixf(Ljava/nio/FloatBuffer;)V glMultMatrix()

--- a/versions/1.17.1-fabric/src/main/kotlin/gg/essential/universal/shader/MCShader.kt
+++ b/versions/1.17.1-fabric/src/main/kotlin/gg/essential/universal/shader/MCShader.kt
@@ -190,10 +190,6 @@ internal class MCSamplerUniform(val mc: Shader, val name: String) : SamplerUnifo
     override val location: Int = 0
 
     override fun setValue(textureId: Int) {
-        //#if MC>=12102
-        //$$ mc.addSamplerTexture(name, textureId)
-        //#else
         mc.addSampler(name, textureId)
-        //#endif
     }
 }

--- a/versions/1.21-1.20.6.txt
+++ b/versions/1.21-1.20.6.txt
@@ -1,2 +1,3 @@
 net.minecraft.client.render.VertexFormatElement type() getComponentType()
 net.minecraft.client.render.VertexFormatElement usage() getType()
+net.minecraft.client.render.VertexFormatElement getSizeInBytes() getByteLength()

--- a/versions/1.21.3-1.21.txt
+++ b/versions/1.21.3-1.21.txt
@@ -1,0 +1,1 @@
+net.minecraft.client.gl.ShaderProgram addSamplerTexture() addSampler()

--- a/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
+++ b/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
@@ -2,6 +2,7 @@ package gg.essential.universal
 
 import com.mojang.blaze3d.systems.ProjectionType
 import com.mojang.blaze3d.systems.RenderSystem
+import gg.essential.universal.render.UGpuTextureView
 import gg.essential.universal.utils.TemporaryTextureAllocator
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gl.RenderPipelines
@@ -97,14 +98,18 @@ internal class AdvancedDrawContext : AutoCloseable {
     }
 
     fun draw(context: DrawContext, texture: TemporaryTextureAllocator.TextureAllocation) {
-        val width = texture.width
-        val height = texture.height
+        draw(context, UGraphics.getPlatformAdapter().textureView(texture.textureView))
+    }
+
+    fun draw(context: DrawContext, textureView: UGpuTextureView) {
+        val width = textureView.texture.width
+        val height = textureView.texture.height
         val scaleFactor = UResolution.scaleFactor.toFloat()
 
         val textureManager = MinecraftClient.getInstance().textureManager
         val identifier = Identifier.of("universalcraft", "__tmp_texture__")
         textureManager.registerTexture(identifier, object : AbstractTexture() {
-            init { glTextureView = texture.textureView }
+            init { this.glTextureView = UGraphics.getPlatformAdapter().textureView(textureView) }
             override fun close() {} // we don't want the later `destroyTexture` to close our texture
         })
 

--- a/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
+++ b/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
@@ -2,13 +2,9 @@ package gg.essential.universal
 
 import com.mojang.blaze3d.systems.ProjectionType
 import com.mojang.blaze3d.systems.RenderSystem
-import gg.essential.universal.render.UGpuTextureView
 import gg.essential.universal.utils.TemporaryTextureAllocator
-import net.minecraft.client.MinecraftClient
-import net.minecraft.client.gl.RenderPipelines
+import gg.essential.universal.utils.drawTexture
 import net.minecraft.client.gui.DrawContext
-import net.minecraft.client.texture.AbstractTexture
-import net.minecraft.util.Identifier
 
 //#if MC >= 26.1
 //#if MC >= 26.2
@@ -98,40 +94,7 @@ internal class AdvancedDrawContext : AutoCloseable {
     }
 
     fun draw(context: DrawContext, texture: TemporaryTextureAllocator.TextureAllocation) {
-        draw(context, UGraphics.getPlatformAdapter().textureView(texture.textureView))
-    }
-
-    fun draw(context: DrawContext, textureView: UGpuTextureView) {
-        val width = textureView.texture.width
-        val height = textureView.texture.height
-        val scaleFactor = UResolution.scaleFactor.toFloat()
-
-        val textureManager = MinecraftClient.getInstance().textureManager
-        val identifier = Identifier.of("universalcraft", "__tmp_texture__")
-        textureManager.registerTexture(identifier, object : AbstractTexture() {
-            init { this.glTextureView = UGraphics.getPlatformAdapter().textureView(textureView) }
-            override fun close() {} // we don't want the later `destroyTexture` to close our texture
-        })
-
-        context.matrices.pushMatrix()
-        context.matrices.scale(1/scaleFactor, 1/scaleFactor) // drawTexture only accepts `int`s
-        context.drawTexture(
-            RenderPipelines.GUI_TEXTURED_PREMULTIPLIED_ALPHA,
-            identifier,
-            // x, y
-            0, 0,
-            // u, v
-            0f, height.toFloat(),
-            // width, height
-            width, height,
-            // uWidth, vHeight
-            width, -height,
-            // textureWidth, textureHeight
-            width, height,
-        )
-        context.matrices.popMatrix()
-
-        textureManager.destroyTexture(identifier)
+        context.drawTexture(UGraphics.getPlatformAdapter().textureView(texture.textureView))
     }
 
     fun nextFrame() {

--- a/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/utils/drawUGpuTexture.kt
+++ b/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/utils/drawUGpuTexture.kt
@@ -1,0 +1,44 @@
+package gg.essential.universal.utils
+
+import gg.essential.universal.UGraphics
+import gg.essential.universal.UResolution
+import gg.essential.universal.render.UGpuTextureView
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gl.RenderPipelines
+import net.minecraft.client.gui.DrawContext
+import net.minecraft.client.texture.AbstractTexture
+import net.minecraft.util.Identifier
+
+internal fun DrawContext.drawTexture(textureView: UGpuTextureView) = drawTextureImpl(this, textureView)
+private fun drawTextureImpl(context: DrawContext, textureView: UGpuTextureView) {
+    val width = textureView.texture.width
+    val height = textureView.texture.height
+    val scaleFactor = UResolution.scaleFactor.toFloat()
+
+    val textureManager = MinecraftClient.getInstance().textureManager
+    val identifier = Identifier.of("universalcraft", "__tmp_texture__")
+    textureManager.registerTexture(identifier, object : AbstractTexture() {
+        init { this.glTextureView = UGraphics.getPlatformAdapter().textureView(textureView) }
+        override fun close() {} // we don't want the later `destroyTexture` to close our texture
+    })
+
+    context.matrices.pushMatrix()
+    context.matrices.scale(1 / scaleFactor, 1 / scaleFactor) // drawTexture only accepts `int`s
+    context.drawTexture(
+        RenderPipelines.GUI_TEXTURED_PREMULTIPLIED_ALPHA,
+        identifier,
+        // x, y
+        0, 0,
+        // u, v
+        0f, height.toFloat(),
+        // width, height
+        width, height,
+        // uWidth, vHeight
+        width, -height,
+        // textureWidth, textureHeight
+        width, height,
+    )
+    context.matrices.popMatrix()
+
+    textureManager.destroyTexture(identifier)
+}

--- a/versions/26.2-fabric/src/main/kotlin/gg/essential/universal/render/UGpuFenceImpl.kt
+++ b/versions/26.2-fabric/src/main/kotlin/gg/essential/universal/render/UGpuFenceImpl.kt
@@ -1,0 +1,10 @@
+// MC >= 26.2
+package gg.essential.universal.render
+
+import com.mojang.blaze3d.systems.RenderSystem
+
+internal class UGpuFenceImpl : UGpuFence {
+    private var mc = RenderSystem.getDevice().createCommandEncoder().createFence()
+    override fun awaitCompletion(timeoutNs: Long): Boolean = mc.awaitCompletion(timeoutNs)
+    override fun close() = mc.close()
+}


### PR DESCRIPTION
This PR introduces a new API for `UScreen` to render things (see last commit), as well as various new primitives in and around `UGpuDevice` which are required for implementing it in Elementa.

The main motivation for the new API is that 26.3 removes `RenderSystem.outputColorTextureOverride`. As such, whenever rendering, the output texture now needs to be specified explicitly, and the new `URenderPass` API allows one to do that.
A secondary motivation for the new API is that all signs indicate that Minecraft will in a future version move rendering to a dedicated thread, separate from the main client thread; so our new API separates extraction of the current gui state from the actual rendering, much like vanilla's `GuiGraphicsExtractor`/`GuiRenderer` separation.